### PR TITLE
Fix addE example in user guide

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -96,7 +96,7 @@ An employee can have any number of tags (including 0)
 
 Examples:
 * `addE n/John Doe p/98765432 e/johnd@example.com a/John street, block 123, #01-01`
-* `addE n/Betsy Crowe t/Junior SWE e/betsycrowe@example.com a/Brick street p/+65 9123 4567 t/Employee of the month`
+* `addE n/Betsy Crowe t/Junior e/betsycrowe@example.com a/Brick street p/91234567 t/Employee`
 
 ### Listing all employees : `listE`
 


### PR DESCRIPTION
The current example for addE will result in the following error message: "Tags names should be alphanumeric"
This is due to spaces in the tags. This PR amends that issue.