### PR TITLE
Refactor Project to use UniqueEmployeeList

### DIFF
--- a/src/main/java/seedu/address/model/employee/Project.java
+++ b/src/main/java/seedu/address/model/employee/Project.java
@@ -23,7 +23,7 @@ public class Project {
     public static final String VALIDATION_REGEX = "[^\\s].*";
 
     public final String name;
-    public final List<Employee> employeeList;
+    public final UniqueEmployeeList employeeList;
 
     /**
      * Constructs a {@code Project}.
@@ -33,7 +33,7 @@ public class Project {
     public Project(String project) {
         requireNonNull(project);
         name = project;
-        employeeList = new ArrayList<>();
+        employeeList = new UniqueEmployeeList();
     }
 
     /**
@@ -42,7 +42,7 @@ public class Project {
      * @param project A valid Project.
      * @param employees A list of Employees that are in the project
      */
-    public Project(String project, List<Employee> employees) {
+    public Project(String project, UniqueEmployeeList employees) {
         requireNonNull(project);
         name = project;
         employeeList = employees;
@@ -82,7 +82,7 @@ public class Project {
                 && otherProject.name.equals(this.name);
     }
 
-    public List<Employee> getEmployees() {
+    public UniqueEmployeeList getEmployees() {
         return employeeList;
     }
 
@@ -91,7 +91,7 @@ public class Project {
         for (Employee employee : employeeList) {
             employeeListString.append(employee.getName() + ", ");
         }
-        if (employeeList.size() != 0) {
+        if (employeeList.asUnmodifiableObservableList().size() != 0) {
             employeeListString.delete(employeeListString.length() - 2,
                     employeeListString.length());
         }

--- a/src/main/java/seedu/address/model/employee/Project.java
+++ b/src/main/java/seedu/address/model/employee/Project.java
@@ -3,8 +3,6 @@ package seedu.address.model.employee;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
 
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedProject.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedProject.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.address.commons.exceptions.IllegalValueException;
-import seedu.address.model.employee.Employee;
 import seedu.address.model.employee.Name;
 import seedu.address.model.employee.Project;
 import seedu.address.model.employee.UniqueEmployeeList;

--- a/src/main/java/seedu/address/storage/JsonAdaptedProject.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedProject.java
@@ -11,6 +11,7 @@ import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.employee.Employee;
 import seedu.address.model.employee.Name;
 import seedu.address.model.employee.Project;
+import seedu.address.model.employee.UniqueEmployeeList;
 
 /**
  * Jackson-friendly version of {@link Project}.
@@ -39,7 +40,7 @@ public class JsonAdaptedProject {
      */
     public JsonAdaptedProject(Project source) {
         name = source.name;
-        employees.addAll(source.getEmployees().stream()
+        employees.addAll(source.getEmployees().asUnmodifiableObservableList().stream()
                 .map(JsonAdaptedEmployee::new)
                 .collect(Collectors.toList()));
     }
@@ -50,7 +51,7 @@ public class JsonAdaptedProject {
      * @throws IllegalValueException if there were any data constraints violated in the adapted employee.
      */
     public Project toModelType() throws IllegalValueException {
-        final List<Employee> employeeList = new ArrayList<>();
+        final UniqueEmployeeList employeeList = new UniqueEmployeeList();
         for (JsonAdaptedEmployee employee : employees) {
             employeeList.add(employee.toModelType());
         }

--- a/src/main/java/seedu/address/ui/ProjectCard.java
+++ b/src/main/java/seedu/address/ui/ProjectCard.java
@@ -42,7 +42,7 @@ public class ProjectCard extends UiPart<Region> {
         id.setText(displayedIndex + ". ");
         name.setText(project.getNameString());
         String listOfEmployeesString =
-                project.getEmployees().size() == 0
+                project.getEmployees().asUnmodifiableObservableList().size() == 0
                 ? "No members yet."
                 : "Members: " + project.getListOfEmployeeNames();
         projects.setText(listOfEmployeesString);

--- a/src/test/java/seedu/address/storage/JsonAdaptedProjectTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedProjectTest.java
@@ -17,7 +17,8 @@ import seedu.address.model.employee.Project;
 public class JsonAdaptedProjectTest {
     public static final String INVALID_NAME = "     ";
     public static final String VALID_NAME = ALPHA.name;
-    public static final List<JsonAdaptedEmployee> VALID_EMPLOYEES = ALPHA.getEmployees().stream()
+    public static final List<JsonAdaptedEmployee> VALID_EMPLOYEES = ALPHA.getEmployees().asUnmodifiableObservableList()
+            .stream()
             .map(JsonAdaptedEmployee::new)
             .collect(Collectors.toList());
 

--- a/src/test/java/seedu/address/testutil/ProjectBuilder.java
+++ b/src/test/java/seedu/address/testutil/ProjectBuilder.java
@@ -8,22 +8,23 @@ import java.util.List;
 
 import seedu.address.model.employee.Employee;
 import seedu.address.model.employee.Project;
+import seedu.address.model.employee.UniqueEmployeeList;
 
 /**
  * A utility class to help with building Project objects.
  */
 public class ProjectBuilder {
     public static final String DEFAULT_NAME = "Alpha";
-    public static final List<Employee> DEFAULT_LIST = new ArrayList<>(Arrays.asList(ALICE));
     private String projectName;
-    private List<Employee> employeeList;
+    private UniqueEmployeeList employeeList;
 
     /**
      * Instantiates a {@code Project} with the default details
      */
     public ProjectBuilder() {
         projectName = DEFAULT_NAME;
-        employeeList = DEFAULT_LIST;
+        employeeList = new UniqueEmployeeList();
+        employeeList.add(ALICE);
     }
 
     /**
@@ -46,7 +47,10 @@ public class ProjectBuilder {
      * Sets the employees of the {@code Project} we are building.
      */
     public ProjectBuilder withEmployees(Employee... employees) {
-        this.employeeList = new ArrayList<>(Arrays.asList(employees));
+        this.employeeList = new UniqueEmployeeList();
+        for(Employee employee : employees) {
+            employeeList.add(employee);
+        }
         return this;
     }
     public Project build() {

--- a/src/test/java/seedu/address/testutil/ProjectBuilder.java
+++ b/src/test/java/seedu/address/testutil/ProjectBuilder.java
@@ -2,10 +2,6 @@ package seedu.address.testutil;
 
 import static seedu.address.testutil.TypicalEmployees.ALICE;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
 import seedu.address.model.employee.Employee;
 import seedu.address.model.employee.Project;
 import seedu.address.model.employee.UniqueEmployeeList;
@@ -48,7 +44,7 @@ public class ProjectBuilder {
      */
     public ProjectBuilder withEmployees(Employee... employees) {
         this.employeeList = new UniqueEmployeeList();
-        for(Employee employee : employees) {
+        for (Employee employee : employees) {
             employeeList.add(employee);
         }
         return this;


### PR DESCRIPTION
Using the built in list to store employees in project caused some unintended results when trying to implement assignE due to the contains(Employee employee) method using equals(Object obj) to check if a list contains an element.

Using UniqueEmployeeList would make more sense as a project should not have duplicate employees, just like how Taskhub doesn't allow employees with the same name.