### PR TITLE
Edit deadlines for projects

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -262,16 +262,16 @@ _Details coming soon ..._
 
 ## Command summary
 
-| Action                         | Format, Examples                                                                                                                                                                                 |
-|--------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **List all employees**         | `listE`                                                                                                                                                                                          |
-| **Clear**                      | `clear`                                                                                                                                                                                          |
-| **Help**                       | `help`                                                                                                                                                                                           |
-| **Add Employee**               | `addE n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [t/TAG]…​ r/REMARK` <br> e.g., `addE n/James Ho p/22224444 e/jamesho@example.com a/123, Clementi Rd, 1234665 t/friend t/colleague r/a good friend` |
-| **Delete Employee**            | `deleteE INDEX`<br> e.g., `deleteE 3`                                                                                                                                                            |
-| **Find Employee**              | `findE KEYWORD [MORE_KEYWORDS]`<br> e.g., `findE James Jake`                                                                                                                                     |
-| **List Projects**              | `listP`                                                                                                                                                                                          |
-| **Add Project**                | `addP pr/PROJECT_NAME [em/EMPLOYEE_INDEX]…​` <br> e.g, `addP pr/CS2103T em/2 3 4 5`                                                                                                              |
-| **Assign Employee to Project** | `assignE pr/PROJECT_INDEX em/EMPLOYEE_INDEX [em/MORE_EMPLOYEE_INDICES]…​` <br> e.g, `assignE pr/4 em/1 2 3`                                                                                      |
-| **Delete Project**             | `deleteP INDEX`<br> e.g., `deleteP 3`                                                                                                                                                            |
+| Action                         | Format, Examples                                                                                                                                                                         |
+|--------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **List all employees**         | `listE`                                                                                                                                                                                  |
+| **Clear**                      | `clear`                                                                                                                                                                                  |
+| **Help**                       | `help`                                                                                                                                                                                   |
+| **Add Employee**               | `addE n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [t/TAG]...` <br> e.g., `addE n/James Ho p/22224444 e/jamesho@example.com a/123, Clementi Rd, 1234665 t/friend t/colleague r/a good friend` |
+| **Delete Employee**            | `deleteE INDEX`<br> e.g., `deleteE 3`                                                                                                                                                    |
+| **Find Employee**              | `findE KEYWORD [MORE_KEYWORDS]`<br> e.g., `findE James Jake`                                                                                                                             |
+| **List Projects**              | `listP`                                                                                                                                                                                  |
+| **Add Project**                | `addP pr/PROJECT_NAME [em/EMPLOYEE_INDEX]…​` <br> e.g, `addP pr/CS2103T em/2 3 4 5`                                                                                                      |
+| **Assign Employee to Project** | `assignE pr/PROJECT_INDEX em/EMPLOYEE_INDEX [em/MORE_EMPLOYEE_INDICES]…​` <br> e.g, `assignE pr/4 em/1 2 3`                                                                              |
+| **Delete Project**             | `deleteP INDEX`<br> e.g., `deleteP 3`                                                                                                                                                    |
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -182,6 +182,24 @@ Examples:
 * `addP pr/Project1 em/1` will add `Project1` to the projects list with the employee index 1 assigned to the project.
 * `addP pr/Project2` will add an empty `Project2` to the projects list.
 
+### Edit deadline of a project: `dl`
+
+Edit the deadline of a project in the projects list.
+
+Format: `dl INDEX d/DATE`
+
+* Edits the deadline of the project at the specified `INDEX`.
+* The index refers to the index number shown in the displayed projects list.
+* The index **must be a positive integer** 1, 2, 3, …
+* The date must be in the `dd/MM/yyyy` format.
+* Existing deadline will be updated to the new deadline.
+* You can remove the deadline by typing `d/` without specifying any date after it.
+
+Examples:
+*  `dl 2 d/18/01/2022` sets the deadline of the 2nd project to be `18/01/2022`.
+*  `dl 1 d/` removes the deadline of the 1st project.
+*  `findP Infinity` followed by `dl 1 d/25/11/2024` sets the deadline of the 1st project in the results of the `findP` command to be `25/11/2024`.
+
 ### Assign employee(s) to a project: `assignE`
 
 Assigns employee(s) to a project in TaskHub

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -191,14 +191,14 @@ Format: `dl INDEX d/DATE`
 * Edits the deadline of the project at the specified `INDEX`.
 * The index refers to the index number shown in the displayed projects list.
 * The index **must be a positive integer** 1, 2, 3, …
-* The date must be in the `dd/MM/yyyy` format.
+* The date must be in the `dd-MM-yyyy` format.
 * Existing deadline will be updated to the new deadline.
 * You can remove the deadline by typing `d/` without specifying any date after it.
 
 Examples:
-*  `dl 2 d/18/01/2022` sets the deadline of the 2nd project to be `18/01/2022`.
+*  `dl 2 d/18-01-2022` sets the deadline of the 2nd project to be `18-01-2022`.
 *  `dl 1 d/` removes the deadline of the 1st project.
-*  `findP Infinity` followed by `dl 1 d/25/11/2024` sets the deadline of the 1st project in the results of the `findP` command to be `25/11/2024`.
+*  `findP Infinity` followed by `dl 1 d/25-11-2024` sets the deadline of the 1st project in the results of the `findP` command to be `25-11-2024`.
 
 ### Assign employee(s) to a project: `assignE`
 
@@ -271,7 +271,8 @@ _Details coming soon ..._
 | **Delete Employee**            | `deleteE INDEX`<br> e.g., `deleteE 3`                                                                                                                                                    |
 | **Find Employee**              | `findE KEYWORD [MORE_KEYWORDS]`<br> e.g., `findE James Jake`                                                                                                                             |
 | **List Projects**              | `listP`                                                                                                                                                                                  |
-| **Add Project**                | `addP pr/PROJECT_NAME [em/EMPLOYEE_INDEX]…​` <br> e.g, `addP pr/CS2103T em/2 3 4 5`                                                                                                      |
+| **Add Project**                | `addP pr/PROJECT_NAME [em/EMPLOYEE_INDEX]…​` <br> e.g, `addP pr/CS2103T em/2 3 4 5`<br/>                                                                                                 |
+| **Edit Project Deadline**      | `dl INDEX d/DATE` <br> e.g., `dl 2 d/27-11-2023` <br>                                                                                                                                     |
 | **Assign Employee to Project** | `assignE pr/PROJECT_INDEX em/EMPLOYEE_INDEX [em/MORE_EMPLOYEE_INDICES]…​` <br> e.g, `assignE pr/4 em/1 2 3`                                                                              |
 | **Delete Project**             | `deleteP INDEX`<br> e.g., `deleteP 3`                                                                                                                                                    |
 

--- a/src/main/java/seedu/address/logic/commands/AssignEmployeeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AssignEmployeeCommand.java
@@ -56,7 +56,7 @@ public class AssignEmployeeCommand extends Command {
         }
 
         Project projectToEdit = lastShownProjectList.get(projectIndex.getZeroBased());
-        Project editedProject = new Project(projectToEdit.name, projectToEdit.employeeList);
+        Project editedProject = new Project(projectToEdit.name, projectToEdit.employeeList, projectToEdit.deadline);
         for (Index employeeIndex : employeeIndexes) {
             if (employeeIndex.getZeroBased() >= lastShownEmployeeList.size()) {
                 throw new CommandException(Messages.MESSAGE_INVALID_EMPLOYEE_DISPLAYED_INDEX);

--- a/src/main/java/seedu/address/logic/commands/AssignEmployeeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AssignEmployeeCommand.java
@@ -75,7 +75,7 @@ public class AssignEmployeeCommand extends Command {
 
     /**
      * Generates a command execution success message based on whether
-     * the remark is added to or removed from
+     * the employees are added to a project.
      * {@code projectToEdit}.
      */
     private String generateSuccessMessage(Project projectToEdit) {

--- a/src/main/java/seedu/address/logic/commands/ProjectDeadlineCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ProjectDeadlineCommand.java
@@ -4,6 +4,7 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DEADLINE;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PROJECTS;
 
+import java.util.List;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
@@ -11,8 +12,6 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.project.Deadline;
 import seedu.address.model.project.Project;
-
-import java.util.List;
 
 /**
  * Adds a deadline to an existing project in TaskHub.

--- a/src/main/java/seedu/address/logic/commands/ProjectDeadlineCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ProjectDeadlineCommand.java
@@ -24,11 +24,11 @@ public class ProjectDeadlineCommand extends Command {
             + "by the index number used in the last project listing. "
             + "Existing deadline will be overwritten by the input.\n"
             + "Parameters: INDEX (must be a positive integer) "
-            + PREFIX_DEADLINE + "[DEADLINE]\n"
+            + PREFIX_DEADLINE + "[DATE]\n"
             + "Example: " + COMMAND_WORD + " 1 "
-            + PREFIX_DEADLINE + "21/02/2021";
+            + PREFIX_DEADLINE + "21-02-2021";
 
-    public static final String MESSAGE_ADD_DEADLINE_SUCCESS = "Added deadline to project: %1$s";
+    public static final String MESSAGE_ADD_DEADLINE_SUCCESS = "Added deadline: %1$s to project: %2$s";
     public static final String MESSAGE_DELETE_DEADLINE_SUCCESS = "Removed deadline from project: %1$s";
 
     private final Index index;
@@ -68,8 +68,10 @@ public class ProjectDeadlineCommand extends Command {
      * {@code projectToEdit}.
      */
     private String generateSuccessMessage(Project projectToEdit) {
-        String message = !deadline.value.isEmpty() ? MESSAGE_ADD_DEADLINE_SUCCESS : MESSAGE_DELETE_DEADLINE_SUCCESS;
-        return String.format(message, projectToEdit);
+        String message = !deadline.value.isEmpty()
+                ? String.format(MESSAGE_ADD_DEADLINE_SUCCESS, this.deadline.toString(), projectToEdit)
+                : String.format(MESSAGE_DELETE_DEADLINE_SUCCESS, projectToEdit);
+        return message;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/ProjectDeadlineCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ProjectDeadlineCommand.java
@@ -35,8 +35,8 @@ public class ProjectDeadlineCommand extends Command {
     private final Deadline deadline;
 
     /**
-     * @param index of the project in the filtered project list to edit the remark
-     * @param deadline of the person to be updated to
+     * @param index of the project in the filtered project list to edit the deadline
+     * @param deadline of the project to be updated to
      */
     public ProjectDeadlineCommand(Index index, Deadline deadline) {
         requireAllNonNull(index, deadline);
@@ -64,8 +64,8 @@ public class ProjectDeadlineCommand extends Command {
     }
 
     /**
-     * Generates a command execution success message based on whether the remark is added to or removed from
-     * {@code personToEdit}.
+     * Generates a command execution success message based on whether the deadline is added to or removed from
+     * {@code projectToEdit}.
      */
     private String generateSuccessMessage(Project projectToEdit) {
         String message = !deadline.value.isEmpty() ? MESSAGE_ADD_DEADLINE_SUCCESS : MESSAGE_DELETE_DEADLINE_SUCCESS;

--- a/src/main/java/seedu/address/logic/commands/ProjectDeadlineCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ProjectDeadlineCommand.java
@@ -1,0 +1,93 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DEADLINE;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PROJECTS;
+
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.project.Deadline;
+import seedu.address.model.project.Project;
+
+import java.util.List;
+
+/**
+ * Adds a deadline to an existing project in TaskHub.
+ */
+public class ProjectDeadlineCommand extends Command {
+
+    public static final String COMMAND_WORD = "dl";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the deadline of a project identified "
+            + "by the index number used in the last project listing. "
+            + "Existing deadline will be overwritten by the input.\n"
+            + "Parameters: INDEX (must be a positive integer) "
+            + PREFIX_DEADLINE + "[DEADLINE]\n"
+            + "Example: " + COMMAND_WORD + " 1 "
+            + PREFIX_DEADLINE + "21/02/2021";
+
+    public static final String MESSAGE_ADD_DEADLINE_SUCCESS = "Added deadline to project: %1$s";
+    public static final String MESSAGE_DELETE_DEADLINE_SUCCESS = "Removed deadline from project: %1$s";
+
+    private final Index index;
+    private final Deadline deadline;
+
+    /**
+     * @param index of the project in the filtered project list to edit the remark
+     * @param deadline of the person to be updated to
+     */
+    public ProjectDeadlineCommand(Index index, Deadline deadline) {
+        requireAllNonNull(index, deadline);
+
+        this.index = index;
+        this.deadline = deadline;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        List<Project> lastShownList = model.getFilteredProjectList();
+
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PROJECT_DISPLAYED_INDEX);
+        }
+
+        Project projectToEdit = lastShownList.get(index.getZeroBased());
+        Project editedProject = new Project(projectToEdit.getNameString(), projectToEdit.getEmployees(),
+                deadline);
+
+        model.setProject(projectToEdit, editedProject);
+        model.updateFilteredProjectList(PREDICATE_SHOW_ALL_PROJECTS);
+
+        return new CommandResult(generateSuccessMessage(editedProject));
+    }
+
+    /**
+     * Generates a command execution success message based on whether the remark is added to or removed from
+     * {@code personToEdit}.
+     */
+    private String generateSuccessMessage(Project projectToEdit) {
+        String message = !deadline.value.isEmpty() ? MESSAGE_ADD_DEADLINE_SUCCESS : MESSAGE_DELETE_DEADLINE_SUCCESS;
+        return String.format(message, projectToEdit);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof ProjectDeadlineCommand)) {
+            return false;
+        }
+
+        // state check
+        ProjectDeadlineCommand e = (ProjectDeadlineCommand) other;
+        return index.equals(e.index)
+                && deadline.equals(e.deadline);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddProjectCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddProjectCommandParser.java
@@ -11,6 +11,8 @@ import java.util.stream.Stream;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.AddProjectCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.employee.UniqueEmployeeList;
+import seedu.address.model.project.Deadline;
 import seedu.address.model.project.Project;
 
 
@@ -42,6 +44,8 @@ public class AddProjectCommandParser implements Parser<AddProjectCommand> {
                 employeeIndexes.add(ParserUtil.parseIndex(index));
             }
         }
+        Deadline deadline = new Deadline("");
+        project = new Project(project.getNameString(), new UniqueEmployeeList(), deadline);
 
         return new AddProjectCommand(project, employeeIndexes);
     }

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -13,5 +13,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_PROJECT = new Prefix("pr/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
     public static final Prefix PREFIX_EMPLOYEE = new Prefix("em/");
+    public static final Prefix PREFIX_DEADLINE = new Prefix("d/");
 
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -13,6 +13,7 @@ import seedu.address.model.employee.Address;
 import seedu.address.model.employee.Email;
 import seedu.address.model.employee.Name;
 import seedu.address.model.employee.Phone;
+import seedu.address.model.project.Deadline;
 import seedu.address.model.project.Project;
 import seedu.address.model.tag.Tag;
 
@@ -136,5 +137,14 @@ public class ParserUtil {
             tagSet.add(parseTag(tagName));
         }
         return tagSet;
+    }
+
+    public static Deadline parseDeadline(String deadline) throws ParseException {
+        requireNonNull(deadline);
+        String trimmedDeadline = deadline.trim();
+        if (!Deadline.isValidDeadline(trimmedDeadline)) {
+            throw new ParseException(Deadline.MESSAGE_CONSTRAINTS);
+        }
+        return new Deadline(trimmedDeadline);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -139,6 +139,12 @@ public class ParserUtil {
         return tagSet;
     }
 
+    /**
+     * Parses a {@code String deadline} into a {@code Deadline}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code deadline} is invalid.
+     */
     public static Deadline parseDeadline(String deadline) throws ParseException {
         requireNonNull(deadline);
         String trimmedDeadline = deadline.trim();

--- a/src/main/java/seedu/address/logic/parser/ProjectDeadlineCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ProjectDeadlineCommandParser.java
@@ -15,7 +15,7 @@ import seedu.address.model.project.Deadline;
 /**
  * Parses input arguments and creates a new ProjectDeadlineCommand object
  */
-public class ProjectDeadlineCommandParser {
+public class ProjectDeadlineCommandParser implements Parser<ProjectDeadlineCommand> {
 
     /**
      * Parses the given {@code String} of arguments in the context of the ProjectDeadlineCommand

--- a/src/main/java/seedu/address/logic/parser/ProjectDeadlineCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ProjectDeadlineCommandParser.java
@@ -1,0 +1,45 @@
+package seedu.address.logic.parser;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.logic.commands.AddEmployeeCommand;
+import seedu.address.logic.commands.ProjectDeadlineCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.project.Deadline;
+
+import java.util.stream.Stream;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DEADLINE;
+
+public class ProjectDeadlineCommandParser {
+    public ProjectDeadlineCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args,
+                PREFIX_DEADLINE);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_DEADLINE)) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ProjectDeadlineCommand.MESSAGE_USAGE));
+        }
+
+        Index index;
+        try {
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (IllegalValueException ive) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    ProjectDeadlineCommand.MESSAGE_USAGE), ive);
+        }
+        Deadline deadline = ParserUtil.parseDeadline(argMultimap.getValue(PREFIX_DEADLINE).get());;
+
+        return new ProjectDeadlineCommand(index, deadline);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/ProjectDeadlineCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ProjectDeadlineCommandParser.java
@@ -1,26 +1,35 @@
 package seedu.address.logic.parser;
 
-import seedu.address.commons.core.index.Index;
-import seedu.address.commons.exceptions.IllegalValueException;
-import seedu.address.logic.commands.AddEmployeeCommand;
-import seedu.address.logic.commands.ProjectDeadlineCommand;
-import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.project.Deadline;
-
-import java.util.stream.Stream;
-
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DEADLINE;
 
+import java.util.stream.Stream;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.logic.commands.ProjectDeadlineCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.project.Deadline;
+
+/**
+ * Parses input arguments and creates a new ProjectDeadlineCommand object
+ */
 public class ProjectDeadlineCommandParser {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the ProjectDeadlineCommand
+     * and returns an ProjectDeadlineCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
     public ProjectDeadlineCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args,
                 PREFIX_DEADLINE);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_DEADLINE)) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ProjectDeadlineCommand.MESSAGE_USAGE));
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    ProjectDeadlineCommand.MESSAGE_USAGE));
         }
 
         Index index;

--- a/src/main/java/seedu/address/logic/parser/TaskHubParser.java
+++ b/src/main/java/seedu/address/logic/parser/TaskHubParser.java
@@ -20,6 +20,7 @@ import seedu.address.logic.commands.FindEmployeeCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListEmployeeCommand;
 import seedu.address.logic.commands.ListProjectCommand;
+import seedu.address.logic.commands.ProjectDeadlineCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -82,6 +83,9 @@ public class TaskHubParser {
 
         case ListProjectCommand.COMMAND_WORD:
             return new ListProjectCommand();
+
+        case ProjectDeadlineCommand.COMMAND_WORD:
+            return new ProjectDeadlineCommandParser().parse(arguments);
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();

--- a/src/main/java/seedu/address/model/project/Deadline.java
+++ b/src/main/java/seedu/address/model/project/Deadline.java
@@ -3,6 +3,7 @@ package seedu.address.model.project;
 import static java.util.Objects.requireNonNull;
 
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 
 /**
  * Represents a Project's deadline in TaskHub.
@@ -11,14 +12,16 @@ import java.time.LocalDate;
 public class Deadline {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Project deadline should be a valid date in the dd/MM/yyyy format.\n Example: 17/02/2009";
+            "Project deadline should be \n"
+                    + "1. an empty string (to remove deadline); or \n"
+                    + "2. a valid date in the dd-MM-yyyy format. Example: 17-02-2009";
+    public static final String DATE_FORMAT = "dd-MM-yyyy";
+    public static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern(DATE_FORMAT);
+
 
     /**
      * Either dd/MM/yyyy or empty string
      */
-    public static final String VALIDATION_REGEX =
-            "^(([0]?[1-9]|[1|2][0-9]|[3][0|1])[/]([0]?[1-9]|[1][0-2])[/]([0-9]{4}))?$";
-
     public final String value;
 
     /**
@@ -35,15 +38,25 @@ public class Deadline {
      * Returns true if a given string is a valid deadline.
      */
     public static boolean isValidDeadline(String test) {
-        return test.matches(VALIDATION_REGEX);
+        // No deadline
+        if (test.equals("")) {
+            return true;
+        }
+
+        // Valid deadline in dd-MM-yyyy format
+        try {
+            LocalDate.parse(test, DATE_FORMATTER);
+            return true; // Parsing success: Valid deadline
+        } catch (Exception e) {
+            return false; // Parsing failed: Invalid deadline
+        }
     }
 
     /**
      * Returns date in LocalDate format
      */
     public LocalDate getLocalDate() {
-        String[] date = value.split("/");
-        return LocalDate.of(Integer.parseInt(date[2]), Integer.parseInt(date[1]), Integer.parseInt(date[0]));
+        return LocalDate.parse(value, DATE_FORMATTER);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/project/Deadline.java
+++ b/src/main/java/seedu/address/model/project/Deadline.java
@@ -20,7 +20,7 @@ public class Deadline {
 
 
     /**
-     * Either dd/MM/yyyy or empty string
+     * Either dd-MM-yyyy or empty string
      */
     public final String value;
 

--- a/src/main/java/seedu/address/model/project/Deadline.java
+++ b/src/main/java/seedu/address/model/project/Deadline.java
@@ -5,16 +5,16 @@ import static java.util.Objects.requireNonNull;
 import java.time.LocalDate;
 
 /**
- * Represents a Person's remark in the address book.
+ * Represents a Project's deadline in TaskHub.
  * Guarantees: immutable; is always valid
  */
 public class Deadline {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Project deadline should be a valid date in the format DD/MM/YY, with leading 0s. E.g.: 17/02/2009";
+            "Project deadline should be a valid date in the dd/MM/yyyy format.\n Example: 17/02/2009";
 
     /**
-     * Either DD/MM/YYYY or empty string
+     * Either dd/MM/yyyy or empty string
      */
     public static final String VALIDATION_REGEX =
             "^(([0]?[1-9]|[1|2][0-9]|[3][0|1])[/]([0]?[1-9]|[1][0-2])[/]([0-9]{4}))?$";

--- a/src/main/java/seedu/address/model/project/Deadline.java
+++ b/src/main/java/seedu/address/model/project/Deadline.java
@@ -1,19 +1,25 @@
 package seedu.address.model.project;
 
-import java.time.LocalDate;
-
 import static java.util.Objects.requireNonNull;
+
+import java.time.LocalDate;
 
 /**
  * Represents a Person's remark in the address book.
  * Guarantees: immutable; is always valid
  */
 public class Deadline {
-    public final String value;
 
     public static final String MESSAGE_CONSTRAINTS =
             "Project deadline should be a valid date in the format DD/MM/YY, with leading 0s. E.g.: 17/02/2009";
-    public static final String VALIDATION_REGEX = "^(([0]?[1-9]|[1|2][0-9]|[3][0|1])[/]([0]?[1-9]|[1][0-2])[/]([0-9]{4}))?$";
+
+    /**
+     * Either DD/MM/YYYY or empty string
+     */
+    public static final String VALIDATION_REGEX =
+            "^(([0]?[1-9]|[1|2][0-9]|[3][0|1])[/]([0]?[1-9]|[1][0-2])[/]([0-9]{4}))?$";
+
+    public final String value;
 
     /**
      * Constructs a {@code Deadline}.
@@ -32,6 +38,9 @@ public class Deadline {
         return test.matches(VALIDATION_REGEX);
     }
 
+    /**
+     * Returns date in LocalDate format
+     */
     public LocalDate getLocalDate() {
         String[] date = value.split("/");
         return LocalDate.of(Integer.parseInt(date[2]), Integer.parseInt(date[1]), Integer.parseInt(date[0]));

--- a/src/main/java/seedu/address/model/project/Deadline.java
+++ b/src/main/java/seedu/address/model/project/Deadline.java
@@ -1,0 +1,56 @@
+package seedu.address.model.project;
+
+import java.time.LocalDate;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Represents a Person's remark in the address book.
+ * Guarantees: immutable; is always valid
+ */
+public class Deadline {
+    public final String value;
+
+    public static final String MESSAGE_CONSTRAINTS =
+            "Project deadline should be a valid date in the format DD/MM/YY, with leading 0s. E.g.: 17/02/2009";
+    public static final String VALIDATION_REGEX = "^(([0]?[1-9]|[1|2][0-9]|[3][0|1])[/]([0]?[1-9]|[1][0-2])[/]([0-9]{4}))?$";
+
+    /**
+     * Constructs a {@code Deadline}.
+     *
+     * @param deadline A valid deadline.
+     */
+    public Deadline(String deadline) {
+        requireNonNull(deadline);
+        value = deadline;
+    }
+
+    /**
+     * Returns true if a given string is a valid deadline.
+     */
+    public static boolean isValidDeadline(String test) {
+        return test.matches(VALIDATION_REGEX);
+    }
+
+    public LocalDate getLocalDate() {
+        String[] date = value.split("/");
+        return LocalDate.of(Integer.parseInt(date[2]), Integer.parseInt(date[1]), Integer.parseInt(date[0]));
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof Deadline // instanceof handles nulls
+                && value.equals(((Deadline) other).value)); // state check
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+}

--- a/src/main/java/seedu/address/model/project/Project.java
+++ b/src/main/java/seedu/address/model/project/Project.java
@@ -8,7 +8,7 @@ import seedu.address.model.employee.Employee;
 import seedu.address.model.employee.UniqueEmployeeList;
 
 /**
- * Represents a Person's remark in the address book.
+ * Represents a Project in TaskHub.
  * Guarantees: immutable; is always valid
  */
 public class Project {

--- a/src/main/java/seedu/address/model/project/Project.java
+++ b/src/main/java/seedu/address/model/project/Project.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNull;
 import java.util.Objects;
 
 import seedu.address.model.employee.Employee;
+import seedu.address.model.employee.Name;
 import seedu.address.model.employee.UniqueEmployeeList;
 
 /**
@@ -22,6 +23,7 @@ public class Project {
     public static final String VALIDATION_REGEX = "[^\\s].*";
 
     public final String name;
+    public final Deadline deadline;
     public final UniqueEmployeeList employeeList;
 
     /**
@@ -31,7 +33,8 @@ public class Project {
      */
     public Project(String project) {
         requireNonNull(project);
-        name = project;
+        this.name = project;
+        this.deadline = new Deadline("");
         employeeList = new UniqueEmployeeList();
     }
 
@@ -41,9 +44,10 @@ public class Project {
      * @param project A valid Project.
      * @param employees A list of Employees that are in the project
      */
-    public Project(String project, UniqueEmployeeList employees) {
+    public Project(String project, UniqueEmployeeList employees, Deadline deadline) {
         requireNonNull(project);
-        name = project;
+        this.name = project;
+        this.deadline = deadline;
         employeeList = employees;
     }
 
@@ -99,6 +103,10 @@ public class Project {
 
     public String getNameString() {
         return this.name;
+    }
+
+    public Deadline getDeadline() {
+        return deadline;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/project/Project.java
+++ b/src/main/java/seedu/address/model/project/Project.java
@@ -5,7 +5,6 @@ import static java.util.Objects.requireNonNull;
 import java.util.Objects;
 
 import seedu.address.model.employee.Employee;
-import seedu.address.model.employee.Name;
 import seedu.address.model.employee.UniqueEmployeeList;
 
 /**

--- a/src/main/java/seedu/address/storage/JsonAdaptedProject.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedProject.java
@@ -11,6 +11,7 @@ import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.employee.Name;
 import seedu.address.model.employee.UniqueEmployeeList;
 import seedu.address.model.employee.exceptions.DuplicateEmployeeException;
+import seedu.address.model.project.Deadline;
 import seedu.address.model.project.Project;
 
 /**
@@ -18,9 +19,10 @@ import seedu.address.model.project.Project;
  */
 
 public class JsonAdaptedProject {
-    public static final String MISSING_FIELD_MESSAGE_FORMAT = "Projects' %s field is missing!";
+    public static final String MISSING_FIELD_MESSAGE_FORMAT = "Project's %s field is missing!";
     private final String name;
     private final List<JsonAdaptedEmployee> employees = new ArrayList<>();
+    private final String deadline;
 
     /**
      * Constructs a {@code JsonAdaptedProject} with the given project details.
@@ -28,11 +30,13 @@ public class JsonAdaptedProject {
 
     @JsonCreator
     public JsonAdaptedProject(@JsonProperty("name") String name,
-                              @JsonProperty("employees") List<JsonAdaptedEmployee> employees) {
+                              @JsonProperty("employees") List<JsonAdaptedEmployee> employees,
+                              @JsonProperty("deadline") String deadline) {
         this.name = name;
         if (employees != null) {
             this.employees.addAll(employees);
         }
+        this.deadline = deadline;
     }
 
     /**
@@ -43,10 +47,11 @@ public class JsonAdaptedProject {
         employees.addAll(source.getEmployees().asUnmodifiableObservableList().stream()
                 .map(JsonAdaptedEmployee::new)
                 .collect(Collectors.toList()));
+        deadline = source.getDeadline().toString();
     }
 
     /**
-     * Converts this Jackson-friendly adapted employee object into the model's {@code Employee} object.
+     * Converts this Jackson-friendly adapted Project object into the model's {@code Project} object.
      *
      * @throws IllegalValueException if there were any data constraints violated in the adapted employee.
      */
@@ -59,13 +64,23 @@ public class JsonAdaptedProject {
         } catch (DuplicateEmployeeException e) {
             throw new IllegalValueException(e.getMessage());
         }
+
         if (name == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName()));
         }
         if (!Project.isValidProject(name)) {
             throw new IllegalValueException(Project.MESSAGE_CONSTRAINTS);
         }
-        return new Project(name, employeeList);
+
+        if (deadline == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Deadline.class.getSimpleName()));
+        }
+        if(!Deadline.isValidDeadline(deadline)) {
+            throw new IllegalValueException(Deadline.MESSAGE_CONSTRAINTS);
+        }
+        final Deadline modelDeadline = new Deadline(this.deadline);
+
+        return new Project(name, employeeList, modelDeadline);
     }
 
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedProject.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedProject.java
@@ -73,9 +73,10 @@ public class JsonAdaptedProject {
         }
 
         if (deadline == null) {
-            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Deadline.class.getSimpleName()));
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
+                    Deadline.class.getSimpleName()));
         }
-        if(!Deadline.isValidDeadline(deadline)) {
+        if (!Deadline.isValidDeadline(deadline)) {
             throw new IllegalValueException(Deadline.MESSAGE_CONSTRAINTS);
         }
         final Deadline modelDeadline = new Deadline(this.deadline);

--- a/src/main/java/seedu/address/ui/ProjectCard.java
+++ b/src/main/java/seedu/address/ui/ProjectCard.java
@@ -6,6 +6,9 @@ import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import seedu.address.model.project.Project;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
 /**
  * An UI component that displays information of a {@code Project}.
  */
@@ -31,6 +34,8 @@ public class ProjectCard extends UiPart<Region> {
     private Label id;
     @FXML
     private Label projects;
+    @FXML
+    private Label deadline;
 
 
     /**
@@ -39,13 +44,38 @@ public class ProjectCard extends UiPart<Region> {
     public ProjectCard(Project project, int displayedIndex) {
         super(FXML);
         this.project = project;
+
+        // Set the index
         id.setText(displayedIndex + ". ");
+
+        // Set the name
         name.setText(project.getNameString());
+
+        // Set the list of employees
         String listOfEmployeesString =
                 project.getEmployees().asUnmodifiableObservableList().size() == 0
                 ? "No members yet."
                 : "Members: " + project.getListOfEmployeeNames();
         projects.setText(listOfEmployeesString);
+
+        // Set the deadline
+        if (project.getDeadline().value == "") {
+            deadline.setText("No deadline set");
+        } else {
+            LocalDate currentDateTime = LocalDate.now(); // Get the current date
+            LocalDate deadlineDate = project.getDeadline().getLocalDate();
+
+            String formattedDeadline = deadlineDate.format(DateTimeFormatter.ofPattern("dd/MM/yyyy")); // Format deadline for display
+            deadline.setText("Deadline: " + formattedDeadline);
+
+            if (deadlineDate.isBefore(currentDateTime)) {
+                // Set the style to red if the deadline is in the past
+                deadline.setStyle("-fx-text-fill: red;");
+            } else {
+                // Set the style to green if the deadline is in the future
+                deadline.setStyle("-fx-text-fill: green;");
+            }
+        }
     }
 
 }

--- a/src/main/java/seedu/address/ui/ProjectCard.java
+++ b/src/main/java/seedu/address/ui/ProjectCard.java
@@ -59,7 +59,7 @@ public class ProjectCard extends UiPart<Region> {
         projects.setText(listOfEmployeesString);
 
         // Set the deadline
-        if (project.getDeadline().value == "") {
+        if (project.getDeadline().value.equals("")) {
             deadline.setText("No deadline set");
         } else {
             LocalDate currentDateTime = LocalDate.now(); // Get the current date

--- a/src/main/java/seedu/address/ui/ProjectCard.java
+++ b/src/main/java/seedu/address/ui/ProjectCard.java
@@ -59,15 +59,16 @@ public class ProjectCard extends UiPart<Region> {
         projects.setText(listOfEmployeesString);
 
         // Set the deadline
-        if (project.getDeadline().value.equals("")) {
+        if (project.getDeadline().value.isEmpty()) {
             deadline.setText("No deadline set");
         } else {
             LocalDate currentDateTime = LocalDate.now(); // Get the current date
-            LocalDate deadlineDate = project.getDeadline().getLocalDate();
+            LocalDate deadlineDate = project.getDeadline().getLocalDate(); // Get project deadline
 
-            String formattedDeadline = deadlineDate.format(DateTimeFormatter.ofPattern("dd/MM/yyyy"));
+            String formattedDeadline = deadlineDate.format(DateTimeFormatter.ofPattern("dd-MM-yyyy"));
             deadline.setText("Deadline: " + formattedDeadline);
 
+            // Compare project deadline with current date
             if (deadlineDate.isBefore(currentDateTime)) {
                 // Set the style to red if the deadline is in the past
                 deadline.setStyle("-fx-text-fill: red;");

--- a/src/main/java/seedu/address/ui/ProjectCard.java
+++ b/src/main/java/seedu/address/ui/ProjectCard.java
@@ -1,13 +1,13 @@
 package seedu.address.ui;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import seedu.address.model.project.Project;
-
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
 
 /**
  * An UI component that displays information of a {@code Project}.
@@ -65,7 +65,7 @@ public class ProjectCard extends UiPart<Region> {
             LocalDate currentDateTime = LocalDate.now(); // Get the current date
             LocalDate deadlineDate = project.getDeadline().getLocalDate();
 
-            String formattedDeadline = deadlineDate.format(DateTimeFormatter.ofPattern("dd/MM/yyyy")); // Format deadline for display
+            String formattedDeadline = deadlineDate.format(DateTimeFormatter.ofPattern("dd/MM/yyyy"));
             deadline.setText("Deadline: " + formattedDeadline);
 
             if (deadlineDate.isBefore(currentDateTime)) {

--- a/src/main/resources/view/ProjectListCard.fxml
+++ b/src/main/resources/view/ProjectListCard.fxml
@@ -3,31 +3,37 @@
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.layout.ColumnConstraints?>
-<?import javafx.scene.layout.FlowPane?>
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.Region?>
+<?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.VBox?>
 
-<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
+<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/20.0.1" xmlns:fx="http://javafx.com/fxml/1">
     <GridPane HBox.hgrow="ALWAYS">
         <columnConstraints>
             <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
         </columnConstraints>
         <VBox alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0">
             <padding>
-                <Insets top="5" right="5" bottom="5" left="15" />
+                <Insets bottom="5" left="15" right="5" top="5" />
             </padding>
-            <HBox spacing="5" alignment="CENTER_LEFT">
+            <HBox alignment="CENTER_LEFT" prefWidth="28.0" spacing="5">
                 <Label fx:id="id" styleClass="cell_big_label">
                     <minWidth>
                         <!-- Ensures that the label text is never truncated -->
                         <Region fx:constant="USE_PREF_SIZE" />
                     </minWidth>
                 </Label>
-                <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
+                <Label fx:id="name" styleClass="cell_big_label" text="\$first" />
             </HBox>
             <Label fx:id="projects" styleClass="cell_small_label" text="\$projects" />
         </VBox>
+        <HBox GridPane.columnIndex="1"> <!-- Set the column index to 1 for the "deadline" label -->
+            <Label fx:id="deadline" styleClass="cell_small_label" text="\$deadline" />
+        </HBox>
+      <rowConstraints>
+         <RowConstraints />
+      </rowConstraints>
     </GridPane>
 </HBox>

--- a/src/test/data/JsonSerializableTaskHubTest/typicalProjectsTaskHub.json
+++ b/src/test/data/JsonSerializableTaskHubTest/typicalProjectsTaskHub.json
@@ -61,7 +61,8 @@
         "project" : "",
         "tags": [ "friends" ]
       }
-    ]
+    ],
+    "deadline" : "22/05/2023"
   }, {
      "name" : "Beta",
      "employees" : [
@@ -73,7 +74,8 @@
          "project" : "",
          "tags" : [ "owesMoney", "friends" ]
        }
-     ]
+     ],
+    "deadline" : "15/11/2024"
     }, {
     "name" : "Delta",
     "employees" : [
@@ -92,6 +94,7 @@
         "project" : "",
         "tags" : [ ]
       }
-    ]
+    ],
+    "deadline" : ""
   }]
 }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DEADLINE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
@@ -20,6 +21,8 @@ import seedu.address.model.Model;
 import seedu.address.model.TaskHub;
 import seedu.address.model.employee.Employee;
 import seedu.address.model.employee.EmployeeNameContainsKeywordsPredicate;
+import seedu.address.model.project.Project;
+import seedu.address.model.project.ProjectNameContainsKeywordsPredicate;
 import seedu.address.testutil.EditEmployeeDescriptorBuilder;
 
 /**
@@ -27,6 +30,7 @@ import seedu.address.testutil.EditEmployeeDescriptorBuilder;
  */
 public class CommandTestUtil {
 
+    // Employee valid fields
     public static final String VALID_NAME_AMY = "Amy Bee";
     public static final String VALID_NAME_BOB = "Bob Choo";
     public static final String VALID_PHONE_AMY = "11111111";
@@ -40,6 +44,11 @@ public class CommandTestUtil {
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";
 
+    // Project valid fields
+    public static final String VALID_DEADLINE_PROJECT_AMY = "21/02/2021";
+    public static final String VALID_DEADLINE_PROJECT_BOB = "15/11/2024";
+
+    // Employee field descriptions
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;
     public static final String PHONE_DESC_AMY = " " + PREFIX_PHONE + VALID_PHONE_AMY;
@@ -52,6 +61,10 @@ public class CommandTestUtil {
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
     public static final String PROJECT_DESC_AMY = " " + PREFIX_PROJECT + VALID_PROJECT_AMY;
     public static final String PROJECT_DESC_BOB = " " + PREFIX_PROJECT + VALID_PROJECT_BOB;
+
+    // Project field descriptions
+    public static final String DEADLINE_PROJECT_DESC_AMY = " " + PREFIX_DEADLINE + VALID_DEADLINE_PROJECT_AMY;
+    public static final String DEADLINE_PROJECT_DESC_BOB = " " + PREFIX_DEADLINE + VALID_DEADLINE_PROJECT_BOB;
 
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
     public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones
@@ -128,6 +141,20 @@ public class CommandTestUtil {
         model.updateFilteredEmployeeList(new EmployeeNameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
 
         assertEquals(1, model.getFilteredEmployeeList().size());
+    }
+
+    /**
+     * Updates {@code model}'s filtered list to show only the project at the given {@code targetIndex} in the
+     * {@code model}'s TaskHub.
+     */
+    public static void showProjectAtIndex(Model model, Index targetIndex) {
+        assertTrue(targetIndex.getZeroBased() < model.getFilteredProjectList().size());
+
+        Project project = model.getFilteredProjectList().get(targetIndex.getZeroBased());
+        final String[] splitName = project.name.split("\\s+");
+        model.updateFilteredProjectList(new ProjectNameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
+
+        assertEquals(1, model.getFilteredProjectList().size());
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/ProjectDeadlineCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ProjectDeadlineCommandTest.java
@@ -1,0 +1,139 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_DEADLINE_PROJECT_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_DEADLINE_PROJECT_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showProjectAtIndex;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PROJECT;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PROJECT;
+import static seedu.address.testutil.TypicalProjects.getTypicalTaskHub;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.project.Deadline;
+import seedu.address.model.project.Project;
+import seedu.address.testutil.ProjectBuilder;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for ProjectDeadlineCommand.
+ */
+public class ProjectDeadlineCommandTest {
+
+    private static final String DEADLINE_STUB = "21/02/2023";
+
+    private Model model = new ModelManager(getTypicalTaskHub(), new UserPrefs());
+
+    @Test
+    public void execute_addDeadlineUnfilteredList_success() {
+        Project firstProject = model.getFilteredProjectList().get(INDEX_FIRST_PROJECT.getZeroBased());
+        Project editedProject = new ProjectBuilder(firstProject)
+                .withDeadline(DEADLINE_STUB).build();
+
+        ProjectDeadlineCommand projectDeadlineCommand = new ProjectDeadlineCommand(INDEX_FIRST_PROJECT,
+                new Deadline(editedProject.getDeadline().value));
+
+        String expectedMessage = String.format(ProjectDeadlineCommand.MESSAGE_ADD_DEADLINE_SUCCESS, editedProject);
+
+        Model expectedModel = new ModelManager(model.getTaskHub(), new UserPrefs());
+        expectedModel.setProject(firstProject, editedProject);
+
+        assertCommandSuccess(projectDeadlineCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_deleteDeadlineUnfilteredList_success() {
+        Project firstProject = model.getFilteredProjectList().get(INDEX_FIRST_PROJECT.getZeroBased());
+        Project editedProject = new ProjectBuilder(firstProject).withDeadline("").build();
+
+        ProjectDeadlineCommand projectDeadlineCommand = new ProjectDeadlineCommand(INDEX_FIRST_PROJECT,
+                new Deadline(editedProject.getDeadline().toString()));
+
+        String expectedMessage = String.format(ProjectDeadlineCommand.MESSAGE_DELETE_DEADLINE_SUCCESS, editedProject);
+
+        Model expectedModel = new ModelManager(model.getTaskHub(), new UserPrefs());
+        expectedModel.setProject(firstProject, editedProject);
+
+        assertCommandSuccess(projectDeadlineCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_filteredList_success() {
+        showProjectAtIndex(model, INDEX_FIRST_PROJECT);
+
+        Project firstProject = model.getFilteredProjectList().get(INDEX_FIRST_PROJECT.getZeroBased());
+        Project editedProject = new ProjectBuilder(model.getFilteredProjectList().get(INDEX_FIRST_PROJECT.getZeroBased()))
+                .withDeadline(DEADLINE_STUB).build();
+
+        ProjectDeadlineCommand projectDeadlineCommand = new ProjectDeadlineCommand(INDEX_FIRST_PROJECT,
+                new Deadline(editedProject.getDeadline().value));
+
+        String expectedMessage = String.format(ProjectDeadlineCommand.MESSAGE_ADD_DEADLINE_SUCCESS, editedProject);
+
+        Model expectedModel = new ModelManager(model.getTaskHub(), new UserPrefs());
+        expectedModel.setProject(firstProject, editedProject);
+
+        assertCommandSuccess(projectDeadlineCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidProjectIndexUnfilteredList_failure() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredProjectList().size() + 1);
+        ProjectDeadlineCommand projectDeadlineCommand = new ProjectDeadlineCommand(outOfBoundIndex,
+                new Deadline(VALID_DEADLINE_PROJECT_BOB));
+
+        assertCommandFailure(projectDeadlineCommand, model, Messages.MESSAGE_INVALID_PROJECT_DISPLAYED_INDEX);
+    }
+
+    /**
+     * Edit filtered list where index is larger than size of filtered list,
+     * but smaller than size of TaskHub
+     */
+    @Test
+    public void execute_invalidProjectIndexFilteredList_failure() {
+        showProjectAtIndex(model, INDEX_FIRST_PROJECT);
+        Index outOfBoundIndex = INDEX_SECOND_PROJECT;
+        // ensures that outOfBoundIndex is still in bounds of TaskHub list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getTaskHub().getProjectList().size());
+
+        ProjectDeadlineCommand projectDeadlineCommand = new ProjectDeadlineCommand(outOfBoundIndex,
+                new Deadline(VALID_DEADLINE_PROJECT_BOB));
+
+        assertCommandFailure(projectDeadlineCommand, model, Messages.MESSAGE_INVALID_PROJECT_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        final ProjectDeadlineCommand standardCommand = new ProjectDeadlineCommand(INDEX_FIRST_PROJECT,
+                new Deadline(VALID_DEADLINE_PROJECT_AMY));
+
+        // same values -> returns true
+        ProjectDeadlineCommand commandWithSameValues = new ProjectDeadlineCommand(INDEX_FIRST_PROJECT,
+                new Deadline(VALID_DEADLINE_PROJECT_AMY));
+        assertTrue(standardCommand.equals(commandWithSameValues));
+
+        // same object -> returns true
+        assertTrue(standardCommand.equals(standardCommand));
+
+        // null -> returns false
+        assertFalse(standardCommand.equals(null));
+
+        // different types -> returns false
+        assertFalse(standardCommand.equals(new ClearCommand()));
+
+        // different index -> returns false
+        assertFalse(standardCommand.equals(new ProjectDeadlineCommand(INDEX_SECOND_PROJECT,
+                new Deadline(VALID_DEADLINE_PROJECT_AMY))));
+
+        // different deadline -> returns false
+        assertFalse(standardCommand.equals(new ProjectDeadlineCommand(INDEX_FIRST_PROJECT,
+                new Deadline(VALID_DEADLINE_PROJECT_BOB))));
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/ProjectDeadlineCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ProjectDeadlineCommandTest.java
@@ -40,7 +40,8 @@ public class ProjectDeadlineCommandTest {
         ProjectDeadlineCommand projectDeadlineCommand = new ProjectDeadlineCommand(INDEX_FIRST_PROJECT,
                 new Deadline(editedProject.getDeadline().value));
 
-        String expectedMessage = String.format(ProjectDeadlineCommand.MESSAGE_ADD_DEADLINE_SUCCESS, editedProject);
+        String expectedMessage = String.format(ProjectDeadlineCommand.MESSAGE_ADD_DEADLINE_SUCCESS,
+                editedProject.getDeadline(), editedProject);
 
         Model expectedModel = new ModelManager(model.getTaskHub(), new UserPrefs());
         expectedModel.setProject(firstProject, editedProject);
@@ -75,7 +76,8 @@ public class ProjectDeadlineCommandTest {
         ProjectDeadlineCommand projectDeadlineCommand = new ProjectDeadlineCommand(INDEX_FIRST_PROJECT,
                 new Deadline(editedProject.getDeadline().value));
 
-        String expectedMessage = String.format(ProjectDeadlineCommand.MESSAGE_ADD_DEADLINE_SUCCESS, editedProject);
+        String expectedMessage = String.format(ProjectDeadlineCommand.MESSAGE_ADD_DEADLINE_SUCCESS,
+                editedProject.getDeadline(), editedProject);
 
         Model expectedModel = new ModelManager(model.getTaskHub(), new UserPrefs());
         expectedModel.setProject(firstProject, editedProject);

--- a/src/test/java/seedu/address/logic/commands/ProjectDeadlineCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ProjectDeadlineCommandTest.java
@@ -13,8 +13,8 @@ import static seedu.address.testutil.TypicalProjects.getTypicalTaskHub;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.logic.Messages;
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -69,8 +69,8 @@ public class ProjectDeadlineCommandTest {
         showProjectAtIndex(model, INDEX_FIRST_PROJECT);
 
         Project firstProject = model.getFilteredProjectList().get(INDEX_FIRST_PROJECT.getZeroBased());
-        Project editedProject = new ProjectBuilder(model.getFilteredProjectList().get(INDEX_FIRST_PROJECT.getZeroBased()))
-                .withDeadline(DEADLINE_STUB).build();
+        Project editedProject = new ProjectBuilder(model.getFilteredProjectList()
+                .get(INDEX_FIRST_PROJECT.getZeroBased())).withDeadline(DEADLINE_STUB).build();
 
         ProjectDeadlineCommand projectDeadlineCommand = new ProjectDeadlineCommand(INDEX_FIRST_PROJECT,
                 new Deadline(editedProject.getDeadline().value));

--- a/src/test/java/seedu/address/logic/parser/ProjectDeadlineCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ProjectDeadlineCommandParserTest.java
@@ -24,7 +24,8 @@ public class ProjectDeadlineCommandParserTest {
     public void parse_validArgs_success() {
         Index targetIndex = INDEX_FIRST_PROJECT;
         String userInput = targetIndex.getOneBased() + " " + PREFIX_DEADLINE + validDeadline;
-        ProjectDeadlineCommand expectedCommand = new ProjectDeadlineCommand(INDEX_FIRST_PROJECT, new Deadline(validDeadline));
+        ProjectDeadlineCommand expectedCommand = new ProjectDeadlineCommand(INDEX_FIRST_PROJECT,
+                new Deadline(validDeadline));
         assertParseSuccess(parser, userInput, expectedCommand);
     }
 

--- a/src/test/java/seedu/address/logic/parser/ProjectDeadlineCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ProjectDeadlineCommandParserTest.java
@@ -1,0 +1,54 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DEADLINE;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PROJECT;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.ProjectDeadlineCommand;
+import seedu.address.model.project.Deadline;
+
+public class ProjectDeadlineCommandParserTest {
+    private static final String MESSAGE_INVALID_FORMAT =
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, ProjectDeadlineCommand.MESSAGE_USAGE);
+
+    private ProjectDeadlineCommandParser parser = new ProjectDeadlineCommandParser();
+    private final String validDeadline = "21/02/2023";
+
+
+    @Test
+    public void parse_validArgs_success() {
+        Index targetIndex = INDEX_FIRST_PROJECT;
+        String userInput = targetIndex.getOneBased() + " " + PREFIX_DEADLINE + validDeadline;
+        ProjectDeadlineCommand expectedCommand = new ProjectDeadlineCommand(INDEX_FIRST_PROJECT, new Deadline(validDeadline));
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_missingDeadlineDate_success() {
+        String userInput = INDEX_FIRST_PROJECT.getOneBased() + " " + PREFIX_DEADLINE + "";
+        ProjectDeadlineCommand expectedCommand = new ProjectDeadlineCommand(INDEX_FIRST_PROJECT, new Deadline(""));
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_missingDeadlinePrefix_failure() {
+        String userInput = INDEX_FIRST_PROJECT.getOneBased() + " " + validDeadline;
+        assertParseFailure(parser, userInput, MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_invalidDeadline_failure() {
+        // Invalid date format
+        String userInput = INDEX_FIRST_PROJECT.getOneBased() + " " + PREFIX_DEADLINE + "21-02-2023";
+        assertParseFailure(parser, userInput, Deadline.MESSAGE_CONSTRAINTS);
+
+        // Invalid date value
+        userInput = INDEX_FIRST_PROJECT.getOneBased() + " " + PREFIX_DEADLINE + "32/02/2023";
+        assertParseFailure(parser, userInput, Deadline.MESSAGE_CONSTRAINTS);
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/ProjectDeadlineCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ProjectDeadlineCommandParserTest.java
@@ -17,7 +17,7 @@ public class ProjectDeadlineCommandParserTest {
             String.format(MESSAGE_INVALID_COMMAND_FORMAT, ProjectDeadlineCommand.MESSAGE_USAGE);
 
     private ProjectDeadlineCommandParser parser = new ProjectDeadlineCommandParser();
-    private final String validDeadline = "21/02/2023";
+    private final String validDeadline = "21-02-2023";
 
 
     @Test
@@ -45,11 +45,11 @@ public class ProjectDeadlineCommandParserTest {
     @Test
     public void parse_invalidDeadline_failure() {
         // Invalid date format
-        String userInput = INDEX_FIRST_PROJECT.getOneBased() + " " + PREFIX_DEADLINE + "21-02-2023";
+        String userInput = INDEX_FIRST_PROJECT.getOneBased() + " " + PREFIX_DEADLINE + "21/02/2023";
         assertParseFailure(parser, userInput, Deadline.MESSAGE_CONSTRAINTS);
 
         // Invalid date value
-        userInput = INDEX_FIRST_PROJECT.getOneBased() + " " + PREFIX_DEADLINE + "32/02/2023";
+        userInput = INDEX_FIRST_PROJECT.getOneBased() + " " + PREFIX_DEADLINE + "32-02-2023";
         assertParseFailure(parser, userInput, Deadline.MESSAGE_CONSTRAINTS);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/TaskHubParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/TaskHubParserTest.java
@@ -128,7 +128,7 @@ public class TaskHubParserTest {
 
     @Test
     public void parseCommand_projectDeadline() throws Exception {
-        final Deadline deadline = new Deadline("12/10/2022");
+        final Deadline deadline = new Deadline("12-10-2022");
         ProjectDeadlineCommand command =
                 (ProjectDeadlineCommand) parser.parseCommand(ProjectDeadlineCommand.COMMAND_WORD + " "
                  + INDEX_FIRST_PROJECT.getOneBased() + " " + PREFIX_DEADLINE + deadline.value);

--- a/src/test/java/seedu/address/logic/parser/TaskHubParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/TaskHubParserTest.java
@@ -4,10 +4,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DEADLINE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMPLOYEE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PROJECT;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_EMPLOYEE;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PROJECT;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -29,9 +31,11 @@ import seedu.address.logic.commands.FindProjectCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListEmployeeCommand;
 import seedu.address.logic.commands.ListProjectCommand;
+import seedu.address.logic.commands.ProjectDeadlineCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.employee.Employee;
 import seedu.address.model.employee.EmployeeNameContainsKeywordsPredicate;
+import seedu.address.model.project.Deadline;
 import seedu.address.model.project.Project;
 import seedu.address.model.project.ProjectNameContainsKeywordsPredicate;
 import seedu.address.testutil.EditEmployeeDescriptorBuilder;
@@ -123,12 +127,22 @@ public class TaskHubParserTest {
     }
 
     @Test
+    public void parseCommand_projectDeadline() throws Exception {
+        final Deadline deadline = new Deadline("12/10/2022");
+        ProjectDeadlineCommand command =
+                (ProjectDeadlineCommand) parser.parseCommand(ProjectDeadlineCommand.COMMAND_WORD + " "
+                 + INDEX_FIRST_PROJECT.getOneBased() + " " + PREFIX_DEADLINE + deadline.value);
+        assertEquals(new ProjectDeadlineCommand(INDEX_FIRST_PROJECT, deadline), command);
+    }
+
+    @Test
     public void parseCommand_newProject() throws Exception {
         AddProjectCommand command = (AddProjectCommand) parser.parseCommand(AddProjectCommand.COMMAND_WORD + " "
                             + PREFIX_PROJECT + "Alpha");
         AddProjectCommand expected = new AddProjectCommand(new Project("Alpha"), new ArrayList<>());
         assertEquals(expected, command);
     }
+
     @Test
     public void parseCommand_unrecognisedInput_throwsParseException() {
         assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE), ()

--- a/src/test/java/seedu/address/model/project/DeadlineTest.java
+++ b/src/test/java/seedu/address/model/project/DeadlineTest.java
@@ -21,30 +21,30 @@ public class DeadlineTest {
 
         // invalid deadlines
         assertFalse(Deadline.isValidDeadline(" ")); // spaces only
-        assertFalse(Deadline.isValidDeadline("32/02/2022")); // invalid date (February 32nd)
-        assertFalse(Deadline.isValidDeadline("01-01-2022")); // invalid date (use of hyphens instead of slashes)
+        assertFalse(Deadline.isValidDeadline("32-02-2022")); // invalid date (February 32nd)
+        assertFalse(Deadline.isValidDeadline("01/01/2022")); // invalid date (use of slashes instead of hyphens)
 
         // valid deadlines
         assertTrue(Deadline.isValidDeadline("")); // empty string, meaning deadline is not set
-        assertTrue(Deadline.isValidDeadline("01/01/2022")); // valid date (January 1st, 2022)
-        assertTrue(Deadline.isValidDeadline("17/02/2009")); // valid date (February 17th, 2009)
-        assertTrue(Deadline.isValidDeadline("01/12/2023")); // valid date (December 1st, 2023)
-        assertTrue(Deadline.isValidDeadline("10/03/1999")); // valid date (March 10th, 1999)
+        assertTrue(Deadline.isValidDeadline("01-01-2022")); // valid date (January 1st, 2022)
+        assertTrue(Deadline.isValidDeadline("17-02-2009")); // valid date (February 17th, 2009)
+        assertTrue(Deadline.isValidDeadline("01-12-2023")); // valid date (December 1st, 2023)
+        assertTrue(Deadline.isValidDeadline("10-03-1999")); // valid date (March 10th, 1999)
     }
 
     @Test
     public void hashCodeGenerator_nonEmptyString_isValidHashCode() {
-        String testDeadlineString = "01/01/2022";
+        String testDeadlineString = "01-01-2022";
         Deadline deadline = new Deadline(testDeadlineString);
         assertEquals(deadline.hashCode(), testDeadlineString.hashCode());
     }
 
     @Test
     public void equals() {
-        Deadline deadline = new Deadline("01/01/2022");
+        Deadline deadline = new Deadline("01-01-2022");
 
         // same values -> returns true
-        assertTrue(deadline.equals(new Deadline("01/01/2022")));
+        assertTrue(deadline.equals(new Deadline("01-01-2022")));
 
         // same object -> returns true
         assertTrue(deadline.equals(deadline));
@@ -56,6 +56,6 @@ public class DeadlineTest {
         assertFalse(deadline.equals(5.0f));
 
         // different values -> returns false
-        assertFalse(deadline.equals(new Deadline("17/02/2009")));
+        assertFalse(deadline.equals(new Deadline("17-02-2009")));
     }
 }

--- a/src/test/java/seedu/address/model/project/DeadlineTest.java
+++ b/src/test/java/seedu/address/model/project/DeadlineTest.java
@@ -1,0 +1,61 @@
+package seedu.address.model.project;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class DeadlineTest {
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Deadline(null));
+    }
+
+    @Test
+    public void isValidDeadline() {
+        // null deadline
+        assertThrows(NullPointerException.class, () -> Deadline.isValidDeadline(null));
+
+        // invalid deadlines
+        assertFalse(Deadline.isValidDeadline(" ")); // spaces only
+        assertFalse(Deadline.isValidDeadline("32/02/2022")); // invalid date (February 32nd)
+        assertFalse(Deadline.isValidDeadline("01-01-2022")); // invalid date (use of hyphens instead of slashes)
+
+        // valid deadlines
+        assertTrue(Deadline.isValidDeadline("")); // empty string, meaning deadline is not set
+        assertTrue(Deadline.isValidDeadline("01/01/2022")); // valid date (January 1st, 2022)
+        assertTrue(Deadline.isValidDeadline("17/02/2009")); // valid date (February 17th, 2009)
+        assertTrue(Deadline.isValidDeadline("01/12/2023")); // valid date (December 1st, 2023)
+        assertTrue(Deadline.isValidDeadline("10/03/1999")); // valid date (March 10th, 1999)
+    }
+
+    @Test
+    public void hashCodeGenerator_nonEmptyString_isValidHashCode() {
+        String testDeadlineString = "01/01/2022";
+        Deadline deadline = new Deadline(testDeadlineString);
+        assertEquals(deadline.hashCode(), testDeadlineString.hashCode());
+    }
+
+    @Test
+    public void equals() {
+        Deadline deadline = new Deadline("01/01/2022");
+
+        // same values -> returns true
+        assertTrue(deadline.equals(new Deadline("01/01/2022")));
+
+        // same object -> returns true
+        assertTrue(deadline.equals(deadline));
+
+        // null -> returns false
+        assertFalse(deadline.equals(null));
+
+        // different types -> returns false
+        assertFalse(deadline.equals(5.0f));
+
+        // different values -> returns false
+        assertFalse(deadline.equals(new Deadline("17/02/2009")));
+    }
+}

--- a/src/test/java/seedu/address/storage/JsonAdaptedProjectTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedProjectTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.employee.Name;
+import seedu.address.model.project.Deadline;
 import seedu.address.model.project.Project;
 
 public class JsonAdaptedProjectTest {
@@ -48,5 +49,19 @@ public class JsonAdaptedProjectTest {
         assertThrows(IllegalValueException.class, expectedMessage, project::toModelType);
     }
 
+    @Test
+    public void toModelType_invalidDeadline_throwsIllegalValueException() {
+        JsonAdaptedProject project =
+                new JsonAdaptedProject(VALID_NAME, VALID_EMPLOYEES, INVALID_DEADLINE);
+        String expectedMessage = Deadline.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, project::toModelType);
+    }
 
+    @Test
+    public void toModelType_nullDeadline_throwsIllegalValueException() {
+        JsonAdaptedProject project =
+                new JsonAdaptedProject(VALID_NAME, VALID_EMPLOYEES, null);
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, "Deadline");
+        assertThrows(IllegalValueException.class, expectedMessage, project::toModelType);
+    }
 }

--- a/src/test/java/seedu/address/storage/JsonAdaptedProjectTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedProjectTest.java
@@ -16,11 +16,15 @@ import seedu.address.model.project.Project;
 
 public class JsonAdaptedProjectTest {
     public static final String INVALID_NAME = "     ";
+    public static final String INVALID_DEADLINE = "32/13/2024";
+
     public static final String VALID_NAME = ALPHA.name;
     public static final List<JsonAdaptedEmployee> VALID_EMPLOYEES = ALPHA.getEmployees().asUnmodifiableObservableList()
             .stream()
             .map(JsonAdaptedEmployee::new)
             .collect(Collectors.toList());
+    public static final String VALID_DEADLINE = ALPHA.getDeadline().toString();
+
 
     @Test
     public void toModelType_validProjectDetails_returnsProject() throws Exception {
@@ -31,7 +35,7 @@ public class JsonAdaptedProjectTest {
     @Test
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedProject project =
-                new JsonAdaptedProject(INVALID_NAME, VALID_EMPLOYEES);
+                new JsonAdaptedProject(INVALID_NAME, VALID_EMPLOYEES, VALID_DEADLINE);
         String expectedMessage = Project.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, project::toModelType);
     }
@@ -39,7 +43,7 @@ public class JsonAdaptedProjectTest {
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
         JsonAdaptedProject project =
-            new JsonAdaptedProject(null, VALID_EMPLOYEES);
+            new JsonAdaptedProject(null, VALID_EMPLOYEES, VALID_DEADLINE);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, project::toModelType);
     }

--- a/src/test/java/seedu/address/testutil/EmployeeBuilder.java
+++ b/src/test/java/seedu/address/testutil/EmployeeBuilder.java
@@ -95,7 +95,7 @@ public class EmployeeBuilder {
     }
 
     /**
-     * Sets the {@code Remark} of the {@code Person} that we are building.
+     * Sets the {@code Project} of the {@code Employee} that we are building.
      */
     public EmployeeBuilder withProject(String project) {
         this.project = new Project(project);

--- a/src/test/java/seedu/address/testutil/ProjectBuilder.java
+++ b/src/test/java/seedu/address/testutil/ProjectBuilder.java
@@ -4,6 +4,7 @@ import static seedu.address.testutil.TypicalEmployees.ALICE;
 
 import seedu.address.model.employee.Employee;
 import seedu.address.model.employee.UniqueEmployeeList;
+import seedu.address.model.project.Deadline;
 import seedu.address.model.project.Project;
 
 /**
@@ -12,8 +13,11 @@ import seedu.address.model.project.Project;
  */
 public class ProjectBuilder {
     public static final String DEFAULT_NAME = "Alpha";
+    public static final String DEFAULT_DEADLINE = "01/01/2020";
+
     private String projectName;
     private UniqueEmployeeList employeeList;
+    private Deadline deadline;
 
     /**
      * Instantiates a {@code Project} with the default details
@@ -22,6 +26,7 @@ public class ProjectBuilder {
         projectName = DEFAULT_NAME;
         employeeList = new UniqueEmployeeList();
         employeeList.add(ALICE);
+        deadline = new Deadline(DEFAULT_DEADLINE);
     }
 
     /**
@@ -30,6 +35,7 @@ public class ProjectBuilder {
     public ProjectBuilder(Project toCopy) {
         projectName = toCopy.name;
         employeeList = toCopy.getEmployees();
+        deadline = toCopy.getDeadline();
     }
 
     /**
@@ -51,6 +57,6 @@ public class ProjectBuilder {
         return this;
     }
     public Project build() {
-        return new Project(projectName, employeeList);
+        return new Project(projectName, employeeList, deadline);
     }
 }

--- a/src/test/java/seedu/address/testutil/ProjectBuilder.java
+++ b/src/test/java/seedu/address/testutil/ProjectBuilder.java
@@ -56,6 +56,15 @@ public class ProjectBuilder {
         }
         return this;
     }
+
+    /**
+     * Sets the {@code Deadline} of the {@code Project} we are building.
+     */
+    public ProjectBuilder withDeadline(String deadline) {
+        this.deadline = new Deadline(deadline);
+        return this;
+    }
+
     public Project build() {
         return new Project(projectName, employeeList, deadline);
     }

--- a/src/test/java/seedu/address/testutil/ProjectBuilder.java
+++ b/src/test/java/seedu/address/testutil/ProjectBuilder.java
@@ -13,7 +13,7 @@ import seedu.address.model.project.Project;
  */
 public class ProjectBuilder {
     public static final String DEFAULT_NAME = "Alpha";
-    public static final String DEFAULT_DEADLINE = "01/01/2020";
+    public static final String DEFAULT_DEADLINE = "";
 
     private String projectName;
     private UniqueEmployeeList employeeList;

--- a/src/test/java/seedu/address/testutil/TypicalIndexes.java
+++ b/src/test/java/seedu/address/testutil/TypicalIndexes.java
@@ -9,4 +9,8 @@ public class TypicalIndexes {
     public static final Index INDEX_FIRST_EMPLOYEE = Index.fromOneBased(1);
     public static final Index INDEX_SECOND_EMPLOYEE = Index.fromOneBased(2);
     public static final Index INDEX_THIRD_EMPLOYEE = Index.fromOneBased(3);
+
+    public static final Index INDEX_FIRST_PROJECT = Index.fromOneBased(1);
+    public static final Index INDEX_SECOND_PROJECT = Index.fromOneBased(2);
+    public static final Index INDEX_THIRD_PROJECT = Index.fromOneBased(3);
 }

--- a/src/test/java/seedu/address/testutil/TypicalProjects.java
+++ b/src/test/java/seedu/address/testutil/TypicalProjects.java
@@ -17,11 +17,14 @@ import seedu.address.model.project.Project;
  */
 public class TypicalProjects {
     public static final Project ALPHA = new ProjectBuilder().build();
-    public static final Project BETA = new ProjectBuilder().withName("Beta").withEmployees(BENSON).build();
-    public static final Project DELTA = new ProjectBuilder().withName("Delta").withEmployees(DANIEL, FIONA).build();
+    public static final Project BETA = new ProjectBuilder().withName("Beta").withEmployees(BENSON)
+            .withDeadline("10/12/2022").build();
+    public static final Project DELTA = new ProjectBuilder().withName("Delta").withEmployees(DANIEL, FIONA)
+            .withDeadline("24/11/2024").build();
 
     //Manually added
-    public static final Project GAMMA = new ProjectBuilder().withName("Gamma").withEmployees(GEORGE).build();
+    public static final Project GAMMA = new ProjectBuilder().withName("Gamma").withEmployees(GEORGE)
+            .withDeadline("08/07/2023").build();
 
     private TypicalProjects() {} // prevents instantiation
 

--- a/src/test/java/seedu/address/testutil/TypicalProjects.java
+++ b/src/test/java/seedu/address/testutil/TypicalProjects.java
@@ -18,13 +18,13 @@ import seedu.address.model.project.Project;
 public class TypicalProjects {
     public static final Project ALPHA = new ProjectBuilder().build();
     public static final Project BETA = new ProjectBuilder().withName("Beta").withEmployees(BENSON)
-            .withDeadline("10/12/2022").build();
+            .withDeadline("10-12-2022").build();
     public static final Project DELTA = new ProjectBuilder().withName("Delta").withEmployees(DANIEL, FIONA)
-            .withDeadline("24/11/2024").build();
+            .withDeadline("24-11-2024").build();
 
     //Manually added
     public static final Project GAMMA = new ProjectBuilder().withName("Gamma").withEmployees(GEORGE)
-            .withDeadline("08/07/2023").build();
+            .withDeadline("08-07-2023").build();
 
     private TypicalProjects() {} // prevents instantiation
 


### PR DESCRIPTION
Closes #107

A new attribute to the `Project` model has been added: `deadline`

Command implemented:

- `dl`

Example usage:

- `dl 3 d/31-10-2023`
- `dl 3 d/`

The string supplied to the `d/` prefix must be of the form dd-MM-yyyy or an empty string.
When an empty string is given as input to the `d/` prefix, the deadline, if present, will be removed.

After merging this PR, users can set deadlines for their projects. The deadlines are color coded as well:

- White if there is no deadline set
- Green if deadline is in the future
- Red if deadline has passed


![image](https://github.com/AY2324S1-CS2103T-T08-3/tp/assets/65384645/ffc87912-c397-4698-9be7-c0500a45affa)
