### PR TITLE
Update AddProjectCommand and AssignEmployeeCommand to use new method in ParserUtil

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddProjectCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddProjectCommandParser.java
@@ -36,10 +36,9 @@ public class AddProjectCommandParser implements Parser<AddProjectCommand> {
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_PROJECT);
         Project project = ParserUtil.parseProject(argMultimap.getValue(PREFIX_PROJECT).get());
         List<Index> employeeIndexes = new ArrayList<>();
+
         if (argMultimap.getValue(PREFIX_EMPLOYEE).isPresent()) {
-            for (String index : argMultimap.getValue(PREFIX_EMPLOYEE).get().split(" ")) {
-                employeeIndexes.add(ParserUtil.parseIndex(index));
-            }
+            employeeIndexes = ParserUtil.parseIndexes(argMultimap.getValue(PREFIX_EMPLOYEE).get());
         }
         project = new Project(project.getNameString());
 

--- a/src/main/java/seedu/address/logic/parser/AssignEmployeeCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AssignEmployeeCommandParser.java
@@ -5,7 +5,6 @@ import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMPLOYEE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PROJECT;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 

--- a/src/main/java/seedu/address/logic/parser/AssignEmployeeCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AssignEmployeeCommandParser.java
@@ -30,16 +30,14 @@ public class AssignEmployeeCommandParser implements Parser<AssignEmployeeCommand
                 PREFIX_PROJECT, PREFIX_EMPLOYEE);
 
         Index index;
-        List<Index> employeeIndexes = new ArrayList<>();
+        List<Index> employeeIndexes;
         try {
             if (!arePrefixesPresent(argMultimap, PREFIX_PROJECT, PREFIX_EMPLOYEE)) {
                 throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                                          AssignEmployeeCommand.MESSAGE_USAGE));
             }
             index = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_PROJECT).get());
-            for (String employeeIndex : argMultimap.getValue(PREFIX_EMPLOYEE).get().split(" ")) {
-                employeeIndexes.add(ParserUtil.parseIndex(employeeIndex));
-            }
+            employeeIndexes = ParserUtil.parseIndexes(argMultimap.getValue(PREFIX_EMPLOYEE).get());
         } catch (IllegalValueException ive) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     AssignEmployeeCommand.MESSAGE_USAGE), ive);


### PR DESCRIPTION
The current implementation manually splits the string to be added in the `employeeIndexes`. Using the new method `ParserUtil.parseIndexes` will improve code resuability and ease of mainenance.

This will not cause any merge conflicts with #138 