### PR TITLE
Remove whitespace at bottom of screen

### DIFF
--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -46,7 +46,7 @@
           </padding>
         </StackPane>
 
-        <SplitPane orientation="HORIZONTAL" dividerPositions="0.4">
+        <SplitPane orientation="HORIZONTAL" dividerPositions="0.4" VBox.vgrow="ALWAYS">
 
           <VBox fx:id="employeeList" styleClass="pane-with-border" minWidth="340" prefWidth="340" VBox.vgrow="ALWAYS">
             <padding>


### PR DESCRIPTION
Close #150
After merging this PR, there will be no whitespace at the bottom of the screen when the user is in full screen mode.