### PR TITLE
Add unassignP command

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -212,17 +212,27 @@ Examples:
 * `findP presentation` returns `Presentation` <br>
   ![result for 'findP presentation'](images/findPpresentationresult.png)
 
-### Assign employee(s) to a project: `assignE`
+### Assign employee(s) to a project: `assignP`
 
 Assigns employee(s) to a project in TaskHub
 
-Format: `assignE pr/PROJECT_INDEX em/EMPLOYEE_INDEX OTHER_EMPLOYEE_INDEXES...`
+Format: `assignP pr/PROJECT_INDEX em/EMPLOYEE_INDEX [MORE_EMPLOYEE_INDEXES] ...`
 * The employee(s) will be assigned to the project
 * Each employee index __must be separated with a space.__
-* The project and employee index refers to the index number shown in the displayed project and employees list.
+* The project and employee index refers to the index number shown in the displayed project and employee list.
 
 Examples:
-* `assignE pr/Project1 em/1 2 3` will add employees 1, 2 and 3 to `Project1`
+* `assignP pr/Project1 em/1 2 3` will add employees 1, 2 and 3 to `Project1`
+
+### Un-assign employee(s) from a project: `unassignP`
+
+Un-assigns employee(s) from a project in TaskHub
+
+Format: `unassignP pr/PROJECT_INDEX em/EMPLOYEE_INDEX [MORE_EMPLOYEE_INDEXES] ...`
+
+* The employee(s) will be unassigned from the project
+* Each employee index __must be separated with a space.__
+* The project and employee index refers to the index number shown in the displayed project and employee list.
 
 ### Delete a project: `deleteP`
 

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -1,6 +1,7 @@
 package seedu.address.logic;
 
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -61,12 +62,21 @@ public class Messages {
     public static String format(Project project) {
         final StringBuilder builder = new StringBuilder();
         builder.append(project.name);
-        builder.append("; Priority: " + project.getProjectPriority().value);
-        builder.append("; Employees: ");
-        for (Employee employee : project.getEmployees()) {
-            builder.append(employee.getName() + ", ");
+        builder.append("; Completion Status: " + project.getCompletionStatus());
+        builder.append("; Deadline: " + project.getDeadline());
+        builder.append("; Priority: " + project.getProjectPriority().value + "\n");
+        builder.append("Employees: ");
+
+        List<Employee> employees = project.getEmployees().asUnmodifiableObservableList();
+        if (!employees.isEmpty()) {
+            builder.append(employees.get(0).getName());
+            for (int i = 1; i < employees.size(); i++) {
+                builder.append(", " + employees.get(i).getName());
+            }
+        } else {
+            builder.append("None");
         }
-        builder.substring(0, builder.lastIndexOf(", ") == -1 ? builder.length() : builder.lastIndexOf(", "));
+
         return builder.toString();
     }
 

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -63,11 +63,11 @@ public class Messages {
      */
     public static String format(Project project) {
         final StringBuilder builder = new StringBuilder();
-        builder.append(project.name);
-        builder.append("; Completion Status: " + project.getCompletionStatus());
-        builder.append("; Deadline: " + project.getDeadline());
+        builder.append("Name: " + project.name);
+        builder.append("; Completed? " + (project.getCompletionStatus().isCompleted ? "Yes" : "No"));
+        builder.append("; Deadline: " + (project.getDeadline().value.isEmpty() ? "Not set" : project.getDeadline()));
         builder.append("; Priority: " + project.getProjectPriority().value + "\n");
-        builder.append("Employees: ");
+        builder.append("Members: ");
 
         List<Employee> employees = project.getEmployees().asUnmodifiableObservableList();
         if (!employees.isEmpty()) {

--- a/src/main/java/seedu/address/logic/commands/AssignProjectCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AssignProjectCommand.java
@@ -30,7 +30,7 @@ public class AssignProjectCommand extends Command {
             + "Example: " + COMMAND_WORD + " " + PREFIX_PROJECT + "1 "
             + PREFIX_EMPLOYEE + "2 3 1";
 
-    public static final String MESSAGE_ADD_PROJECT_SUCCESS = "Updated project : %1$s";
+    public static final String MESSAGE_ADD_PROJECT_SUCCESS = "Member(s) have been assigned!\n%1$s";
 
 
     private final Index projectIndex;

--- a/src/main/java/seedu/address/logic/commands/AssignProjectCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AssignProjectCommand.java
@@ -17,9 +17,9 @@ import seedu.address.model.project.Project;
 /**
  * Assigns an existing project to a number of existing employees in the TaskHub.
  */
-public class AssignEmployeeCommand extends Command {
+public class AssignProjectCommand extends Command {
 
-    public static final String COMMAND_WORD = "assignE";
+    public static final String COMMAND_WORD = "assignP";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Edits the project of the employees identified "
@@ -40,7 +40,7 @@ public class AssignEmployeeCommand extends Command {
      * @param projectIndex index of the project in the filtered project list to update
      * @param employeeIndexes index of the employees in the filtered employee list to be added to the project
      */
-    public AssignEmployeeCommand(Index projectIndex, List<Index> employeeIndexes) {
+    public AssignProjectCommand(Index projectIndex, List<Index> employeeIndexes) {
         requireAllNonNull(projectIndex, employeeIndexes);
 
         this.projectIndex = projectIndex;
@@ -90,11 +90,11 @@ public class AssignEmployeeCommand extends Command {
         }
 
         // instanceof handles nulls
-        if (!(other instanceof AssignEmployeeCommand)) {
+        if (!(other instanceof AssignProjectCommand)) {
             return false;
         }
 
-        AssignEmployeeCommand e = (AssignEmployeeCommand) other;
+        AssignProjectCommand e = (AssignProjectCommand) other;
         return projectIndex.equals(e.projectIndex)
                 && employeeIndexes.equals(e.employeeIndexes);
     }

--- a/src/main/java/seedu/address/logic/commands/UnassignProjectCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnassignProjectCommand.java
@@ -32,10 +32,11 @@ public class UnassignProjectCommand extends Command {
 
     public static final String MESSAGE_UNASSIGN_PROJECT_SUCCESS = "Updated project : %1$s";
     public static final String MESSAGE_UNASSIGN_PROJECT_FAILURE = "The following employee is not in the specified "
-            + "project \n"
-            + "Employee: %1$s (Index: %2$s)\n"
+            + "project. \n"
+            + "Employee: %1$s (Index: %2$s) "
             + "Project: %3$s (Index: %4$s)\n"
-            + "Please check the project and employee index again.";
+            + "Please check the project and employee index again. "
+            + "Using the findP command to isolate the project and it's employees may be useful.";
 
     private final Index projectIndex;
     private final List<Index> employeeIndexes;

--- a/src/main/java/seedu/address/logic/commands/UnassignProjectCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnassignProjectCommand.java
@@ -81,10 +81,6 @@ public class UnassignProjectCommand extends Command {
 
         // Remove employees from project
         for (Index employeeIndex : employeeIndexes) {
-            if (employeeIndex.getZeroBased() >= lastShownEmployeeList.size()) {
-                throw new CommandException(Messages.MESSAGE_INVALID_EMPLOYEE_DISPLAYED_INDEX);
-            }
-
             Employee employeeToRemove = lastShownEmployeeList.get(employeeIndex.getZeroBased());
             editedProject.removeEmployee(employeeToRemove);
         }

--- a/src/main/java/seedu/address/logic/commands/UnassignProjectCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnassignProjectCommand.java
@@ -36,7 +36,7 @@ public class UnassignProjectCommand extends Command {
             + "Employee: %1$s (Index: %2$s) "
             + "Project: %3$s (Index: %4$s)\n"
             + "Please check the project and employee index again. "
-            + "Using the findP command to isolate the project and it's employees may be useful.";
+            + "Using the findP command to isolate the project and its employees may be useful.";
 
     private final Index projectIndex;
     private final List<Index> employeeIndexes;
@@ -65,7 +65,7 @@ public class UnassignProjectCommand extends Command {
         Project editedProject = new Project(projectToEdit.name, projectToEdit.employeeList, projectToEdit.getTasks(),
                 projectToEdit.getProjectPriority(), projectToEdit.getDeadline(), projectToEdit.getCompletionStatus());
 
-        // Check if all employees are in the project
+        // Check if all specified employees are in the project
         for (Index employeeIndex : employeeIndexes) {
             if (employeeIndex.getZeroBased() >= lastShownEmployeeList.size()) {
                 throw new CommandException(Messages.MESSAGE_INVALID_EMPLOYEE_DISPLAYED_INDEX);
@@ -79,7 +79,7 @@ public class UnassignProjectCommand extends Command {
             }
         }
 
-        // Remove employees from project
+        // Remove specified employees from project
         for (Index employeeIndex : employeeIndexes) {
             Employee employeeToRemove = lastShownEmployeeList.get(employeeIndex.getZeroBased());
             editedProject.removeEmployee(employeeToRemove);

--- a/src/main/java/seedu/address/logic/commands/UnassignProjectCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnassignProjectCommand.java
@@ -1,0 +1,110 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMPLOYEE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PROJECT;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_EMPLOYEES;
+
+import java.util.List;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.employee.Employee;
+import seedu.address.model.project.Project;
+
+public class UnassignProjectCommand extends Command {
+
+    public static final String COMMAND_WORD = "unassignP";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Unassigns the project of the employees identified "
+            + "by the index number used in the last employee listing. "
+            + "\n"
+            + "Parameters: PROJECT_INDEX, EMPLOYEE_INDEX (must be a positive integer) "
+            + "pr/[PROJECT_INDEX] em/[EMPLOYEE_INDEX ...]\n"
+            + "Example: " + COMMAND_WORD + " " + PREFIX_PROJECT + "1 "
+            + PREFIX_EMPLOYEE + "2 3 1";
+
+    public static final String MESSAGE_UNASSIGN_PROJECT_SUCCESS = "Updated project : %1$s";
+    public static final String MESSAGE_UNASSIGN_PROJECT_FAILURE = "The following employee is not in the specified "
+            + "project \n"
+            + "Employee: %1$s (Index: %2$s)\n"
+            + "Project: %3$s (Index: %4$s)\n"
+            + "Please check the project and employee index again.";
+
+    private final Index projectIndex;
+    private final List<Index> employeeIndexes;
+
+    public UnassignProjectCommand(Index projectIndex, List<Index> employeeIndexes) {
+        requireAllNonNull(projectIndex, employeeIndexes);
+
+        this.projectIndex = projectIndex;
+        this.employeeIndexes = employeeIndexes;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        List<Employee> lastShownEmployeeList = model.getFilteredEmployeeList();
+        List<Project> lastShownProjectList = model.getFilteredProjectList();
+
+        if (projectIndex.getZeroBased() >= lastShownProjectList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PROJECT_DISPLAYED_INDEX);
+        }
+
+        Project projectToEdit = lastShownProjectList.get(projectIndex.getZeroBased());
+        Project editedProject = new Project(projectToEdit.name, projectToEdit.employeeList, projectToEdit.getTasks(),
+                projectToEdit.getProjectPriority(), projectToEdit.getDeadline(), projectToEdit.getCompletionStatus());
+
+        // Check if all employees are in the project
+        for (Index employeeIndex : employeeIndexes) {
+            if (employeeIndex.getZeroBased() >= lastShownEmployeeList.size()) {
+                throw new CommandException(Messages.MESSAGE_INVALID_EMPLOYEE_DISPLAYED_INDEX);
+            }
+
+            Employee employeeToRemove = lastShownEmployeeList.get(employeeIndex.getZeroBased());
+            if (!editedProject.employeeList.contains(employeeToRemove)) {
+                throw new CommandException(String.format(MESSAGE_UNASSIGN_PROJECT_FAILURE,
+                        employeeToRemove.getName(), employeeIndex.getOneBased(),
+                        projectToEdit.name, projectIndex.getOneBased()));
+            }
+        }
+
+        // Remove employees from project
+        for (Index employeeIndex : employeeIndexes) {
+            if (employeeIndex.getZeroBased() >= lastShownEmployeeList.size()) {
+                throw new CommandException(Messages.MESSAGE_INVALID_EMPLOYEE_DISPLAYED_INDEX);
+            }
+
+            Employee employeeToRemove = lastShownEmployeeList.get(employeeIndex.getZeroBased());
+            editedProject.removeEmployee(employeeToRemove);
+        }
+
+        model.setProject(projectToEdit, editedProject);
+        model.updateFilteredEmployeeList(PREDICATE_SHOW_ALL_EMPLOYEES);
+
+        return new CommandResult(generateSuccessMessage(editedProject));
+    }
+
+    private String generateSuccessMessage(Project projectToEdit) {
+        return String.format(MESSAGE_UNASSIGN_PROJECT_SUCCESS, Messages.format(projectToEdit));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof UnassignProjectCommand)) {
+            return false;
+        }
+
+        // state check
+        UnassignProjectCommand e = (UnassignProjectCommand) other;
+        return projectIndex.equals(e.projectIndex)
+                && employeeIndexes.equals(e.employeeIndexes);
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/UnassignProjectCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnassignProjectCommand.java
@@ -30,7 +30,7 @@ public class UnassignProjectCommand extends Command {
             + "Example: " + COMMAND_WORD + " " + PREFIX_PROJECT + "1 "
             + PREFIX_EMPLOYEE + "2 3 1";
 
-    public static final String MESSAGE_UNASSIGN_PROJECT_SUCCESS = "Updated project : %1$s";
+    public static final String MESSAGE_UNASSIGN_PROJECT_SUCCESS = "Member(s) have been un-assigned!\n%1$s";
     public static final String MESSAGE_UNASSIGN_PROJECT_FAILURE = "The following employee is not in the specified "
             + "project. \n"
             + "Employee: %1$s (Index: %2$s) "

--- a/src/main/java/seedu/address/logic/parser/AssignProjectCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AssignProjectCommandParser.java
@@ -10,20 +10,20 @@ import java.util.stream.Stream;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.exceptions.IllegalValueException;
-import seedu.address.logic.commands.AssignEmployeeCommand;
+import seedu.address.logic.commands.AssignProjectCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
- * Parses input arguments and creates a new AssignEmployeeCommand object
+ * Parses input arguments and creates a new AssignProjectCommand object
  */
-public class AssignEmployeeCommandParser implements Parser<AssignEmployeeCommand> {
+public class AssignProjectCommandParser implements Parser<AssignProjectCommand> {
     /**
-     * Parses the given {@code String} of arguments in the context of the {@code AssignEmployeeCommand}
-     * and returns a {@code AssignEmployeeCommand} object for execution.
+     * Parses the given {@code String} of arguments in the context of the {@code AssignProjectCommand}
+     * and returns a {@code AssignProjectCommand} object for execution.
      *
      * @throws ParseException if the user input does not conform to the expected format.
      */
-    public AssignEmployeeCommand parse(String args) throws ParseException {
+    public AssignProjectCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args,
                 PREFIX_PROJECT, PREFIX_EMPLOYEE);
@@ -33,16 +33,16 @@ public class AssignEmployeeCommandParser implements Parser<AssignEmployeeCommand
         try {
             if (!arePrefixesPresent(argMultimap, PREFIX_PROJECT, PREFIX_EMPLOYEE)) {
                 throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                                         AssignEmployeeCommand.MESSAGE_USAGE));
+                                         AssignProjectCommand.MESSAGE_USAGE));
             }
             index = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_PROJECT).get());
             employeeIndexes = ParserUtil.parseIndexes(argMultimap.getValue(PREFIX_EMPLOYEE).get());
         } catch (IllegalValueException ive) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    AssignEmployeeCommand.MESSAGE_USAGE), ive);
+                    AssignProjectCommand.MESSAGE_USAGE), ive);
         }
 
-        return new AssignEmployeeCommand(index, employeeIndexes);
+        return new AssignProjectCommand(index, employeeIndexes);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/MarkProjectCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/MarkProjectCommandParser.java
@@ -19,14 +19,14 @@ public class MarkProjectCommandParser implements Parser<MarkProjectCommand> {
         requireNonNull(args);
         assert args != null;
 
-        try {
-            List<Index> indexes = ParserUtil.parseIndexes(args);
-            assert indexes.size() > 0;
-
-            return new MarkProjectCommand(indexes);
-        } catch (ParseException pe) {
+        if (args.isEmpty()) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, MarkProjectCommand.MESSAGE_USAGE), pe);
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, MarkProjectCommand.MESSAGE_USAGE));
         }
+
+        List<Index> indexes = ParserUtil.parseIndexes(args);
+        assert indexes.size() > 0;
+
+        return new MarkProjectCommand(indexes);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -31,6 +31,8 @@ import seedu.address.model.task.Task;
 public class ParserUtil {
 
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
+    public static final String MESSAGE_DUPLICATE_INDEX = "Duplicate indexes are not allowed. \n"
+            + "Duplicate Index: %1$s";
 
     private static final Logger logger = LogsCenter.getLogger(ParserUtil.class);
 
@@ -63,8 +65,8 @@ public class ParserUtil {
 
         for (String index : trimmedIndexes) {
             if (uniqueStringSet.contains(index)) {
-                logger.warning("Duplicate indexes are not allowed. \n" + "Duplicate Index: " + index);
-                throw new ParseException("Duplicate indexes are not allowed.\n" + "Duplicate Index: " + index);
+                logger.warning(String.format(MESSAGE_DUPLICATE_INDEX, index));
+                throw new ParseException(String.format(MESSAGE_DUPLICATE_INDEX, index));
             } else {
                 uniqueStringSet.add(index);
                 indexList.add(parseIndex(index));

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -30,7 +30,8 @@ import seedu.address.model.task.Task;
  */
 public class ParserUtil {
 
-    public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
+    public static final String MESSAGE_INVALID_INDEX = "Index provided was not a non-zero unsigned integer.\n"
+            + "This is not valid: %1$s";
     public static final String MESSAGE_DUPLICATE_INDEX = "Duplicate indexes are not allowed. \n"
             + "Duplicate Index: %1$s";
 
@@ -45,7 +46,8 @@ public class ParserUtil {
         String trimmedIndex = oneBasedIndex.trim();
         if (!StringUtil.isNonZeroUnsignedInteger(trimmedIndex)) {
             logger.warning("Expected a non-zero unsigned integer but received: " + trimmedIndex + ".");
-            throw new ParseException(MESSAGE_INVALID_INDEX);
+            throw new ParseException(String.format(MESSAGE_INVALID_INDEX,
+                    trimmedIndex.isEmpty() ? "<empty>" : trimmedIndex));
         }
 
         assert Integer.parseInt(trimmedIndex) > 0;

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -59,8 +59,16 @@ public class ParserUtil {
     public static List<Index> parseIndexes(String oneBasedIndexes) throws ParseException {
         String[] trimmedIndexes = oneBasedIndexes.trim().split(" ");
         List<Index> indexList = new ArrayList<>();
+        Set<String> uniqueStringSet = new HashSet<>();
+
         for (String index : trimmedIndexes) {
-            indexList.add(parseIndex(index));
+            if (uniqueStringSet.contains(index)) {
+                logger.warning("Duplicate indexes are not allowed. \n" + "Duplicate Index: " + index);
+                throw new ParseException("Duplicate indexes are not allowed.\n" + "Duplicate Index: " + index);
+            } else {
+                uniqueStringSet.add(index);
+                indexList.add(parseIndex(index));
+            }
         }
 
         assert indexList != null;

--- a/src/main/java/seedu/address/logic/parser/ProjectDeadlineCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ProjectDeadlineCommandParser.java
@@ -30,6 +30,7 @@ public class ProjectDeadlineCommandParser implements Parser<ProjectDeadlineComma
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     ProjectDeadlineCommand.MESSAGE_USAGE));
         }
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_DEADLINE);
 
         Index index;
         try {

--- a/src/main/java/seedu/address/logic/parser/ProjectDeadlineCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ProjectDeadlineCommandParser.java
@@ -30,7 +30,6 @@ public class ProjectDeadlineCommandParser implements Parser<ProjectDeadlineComma
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     ProjectDeadlineCommand.MESSAGE_USAGE));
         }
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_DEADLINE);
 
         Index index;
         try {

--- a/src/main/java/seedu/address/logic/parser/TaskHubParser.java
+++ b/src/main/java/seedu/address/logic/parser/TaskHubParser.java
@@ -27,6 +27,7 @@ import seedu.address.logic.commands.ListProjectCommand;
 import seedu.address.logic.commands.MarkProjectCommand;
 import seedu.address.logic.commands.PriorityProjectCommand;
 import seedu.address.logic.commands.ProjectDeadlineCommand;
+import seedu.address.logic.commands.UnassignProjectCommand;
 import seedu.address.logic.commands.UnmarkProjectCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -76,6 +77,9 @@ public class TaskHubParser {
 
         case AssignEmployeeCommand.COMMAND_WORD:
             return new AssignEmployeeCommandParser().parse(arguments);
+
+        case UnassignProjectCommand.COMMAND_WORD:
+            return new UnassignProjectCommandParser().parse(arguments);
 
         case DeleteEmployeeCommand.COMMAND_WORD:
             return new DeleteEmployeeCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/TaskHubParser.java
+++ b/src/main/java/seedu/address/logic/parser/TaskHubParser.java
@@ -11,7 +11,7 @@ import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.AddEmployeeCommand;
 import seedu.address.logic.commands.AddProjectCommand;
 import seedu.address.logic.commands.AddTaskCommand;
-import seedu.address.logic.commands.AssignEmployeeCommand;
+import seedu.address.logic.commands.AssignProjectCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteEmployeeCommand;
@@ -75,8 +75,8 @@ public class TaskHubParser {
         case EditCommand.COMMAND_WORD:
             return new EditCommandParser().parse(arguments);
 
-        case AssignEmployeeCommand.COMMAND_WORD:
-            return new AssignEmployeeCommandParser().parse(arguments);
+        case AssignProjectCommand.COMMAND_WORD:
+            return new AssignProjectCommandParser().parse(arguments);
 
         case UnassignProjectCommand.COMMAND_WORD:
             return new UnassignProjectCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/UnassignProjectCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UnassignProjectCommandParser.java
@@ -1,0 +1,44 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMPLOYEE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PROJECT;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.logic.commands.UnassignProjectCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+public class UnassignProjectCommandParser implements Parser<UnassignProjectCommand> {
+
+    public UnassignProjectCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args,
+                PREFIX_PROJECT, PREFIX_EMPLOYEE);
+
+        Index projectIndex;
+        List<Index> employeeIndexes;
+
+        try {
+            if (!arePrefixesPresent(argMultimap, PREFIX_PROJECT, PREFIX_EMPLOYEE)) {
+                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                                         UnassignProjectCommand.MESSAGE_USAGE));
+            }
+            projectIndex = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_PROJECT).get());
+            employeeIndexes = ParserUtil.parseIndexes(argMultimap.getValue(PREFIX_EMPLOYEE).get());
+        } catch (IllegalValueException ive) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    UnassignProjectCommand.MESSAGE_USAGE), ive);
+        }
+
+        return new UnassignProjectCommand(projectIndex, employeeIndexes);
+    }
+
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/UnassignProjectCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UnassignProjectCommandParser.java
@@ -32,6 +32,7 @@ public class UnassignProjectCommandParser implements Parser<UnassignProjectComma
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                                      UnassignProjectCommand.MESSAGE_USAGE));
         }
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_PROJECT, PREFIX_EMPLOYEE);
 
         Index projectIndex;
         List<Index> employeeIndexes;

--- a/src/main/java/seedu/address/logic/parser/UnassignProjectCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UnassignProjectCommandParser.java
@@ -9,7 +9,6 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import seedu.address.commons.core.index.Index;
-import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.logic.commands.UnassignProjectCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -20,20 +19,16 @@ public class UnassignProjectCommandParser implements Parser<UnassignProjectComma
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args,
                 PREFIX_PROJECT, PREFIX_EMPLOYEE);
 
+        if (!arePrefixesPresent(argMultimap, PREFIX_PROJECT, PREFIX_EMPLOYEE)) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                                     UnassignProjectCommand.MESSAGE_USAGE));
+        }
+
         Index projectIndex;
         List<Index> employeeIndexes;
 
-        try {
-            if (!arePrefixesPresent(argMultimap, PREFIX_PROJECT, PREFIX_EMPLOYEE)) {
-                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                                         UnassignProjectCommand.MESSAGE_USAGE));
-            }
-            projectIndex = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_PROJECT).get());
-            employeeIndexes = ParserUtil.parseIndexes(argMultimap.getValue(PREFIX_EMPLOYEE).get());
-        } catch (IllegalValueException ive) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    UnassignProjectCommand.MESSAGE_USAGE), ive);
-        }
+        projectIndex = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_PROJECT).get());
+        employeeIndexes = ParserUtil.parseIndexes(argMultimap.getValue(PREFIX_EMPLOYEE).get());
 
         return new UnassignProjectCommand(projectIndex, employeeIndexes);
     }

--- a/src/main/java/seedu/address/logic/parser/UnmarkProjectCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UnmarkProjectCommandParser.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import java.util.List;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.MarkProjectCommand;
 import seedu.address.logic.commands.UnmarkProjectCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -19,14 +20,14 @@ public class UnmarkProjectCommandParser implements Parser<UnmarkProjectCommand> 
         requireNonNull(args);
         assert args != null;
 
-        try {
-            List<Index> indexes = ParserUtil.parseIndexes(args);
-            assert indexes.size() > 0;
-
-            return new UnmarkProjectCommand(indexes);
-        } catch (ParseException pe) {
+        if (args.isEmpty()) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnmarkProjectCommand.MESSAGE_USAGE), pe);
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, MarkProjectCommand.MESSAGE_USAGE));
         }
+
+        List<Index> indexes = ParserUtil.parseIndexes(args);
+        assert indexes.size() > 0;
+
+        return new UnmarkProjectCommand(indexes);
     }
 }

--- a/src/main/java/seedu/address/model/employee/UniqueEmployeeList.java
+++ b/src/main/java/seedu/address/model/employee/UniqueEmployeeList.java
@@ -49,6 +49,20 @@ public class UniqueEmployeeList implements Iterable<Employee> {
     }
 
     /**
+     * Returns true if the list is empty.
+     */
+    public boolean isEmpty() {
+        return internalList.isEmpty();
+    }
+
+    /**
+     * Returns the size of the list.
+     */
+    public int size() {
+        return internalList.size();
+    }
+
+    /**
      * Replaces the employee {@code target} in the list with {@code editedEmployee}.
      * {@code target} must exist in the list.
      * The employee identity of {@code editedEmployee} must not be the same as another existing employee in the list.

--- a/src/test/java/seedu/address/logic/commands/AssignProjectCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AssignProjectCommandTest.java
@@ -20,17 +20,17 @@ import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.testutil.ProjectBuilder;
 
-public class AssignEmployeeCommandTest {
+public class AssignProjectCommandTest {
     private Model model = new ModelManager(getTypicalTaskHub(), new UserPrefs());
 
     @Test
     public void constructor_nullProjectIndex_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> new AssignEmployeeCommand(null, new ArrayList<>()));
+        assertThrows(NullPointerException.class, () -> new AssignProjectCommand(null, new ArrayList<>()));
     }
 
     @Test
     public void constructor_nullEmployeeIndexes_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> new AssignEmployeeCommand(Index.fromOneBased(1),
+        assertThrows(NullPointerException.class, () -> new AssignProjectCommand(Index.fromOneBased(1),
                                                                     null));
     }
     @Test
@@ -38,22 +38,22 @@ public class AssignEmployeeCommandTest {
 
         Model expectedModel = new ModelManager(getTypicalTaskHub(), new UserPrefs());
         expectedModel.setProject(ALPHA, new ProjectBuilder(ALPHA).withEmployees(ALICE, BENSON).build());
-        AssignEmployeeCommand assignEmployeeCommand =
-                new AssignEmployeeCommand(Index.fromOneBased(1),
+        AssignProjectCommand assignProjectCommand =
+                new AssignProjectCommand(Index.fromOneBased(1),
                         new ArrayList<>(Arrays.asList(Index.fromOneBased(2))));
-        String expectedMessage = String.format(AssignEmployeeCommand.MESSAGE_ADD_PROJECT_SUCCESS,
+        String expectedMessage = String.format(AssignProjectCommand.MESSAGE_ADD_PROJECT_SUCCESS,
                 Messages.format(expectedModel.getFilteredProjectList().get(0)));
-        assertCommandSuccess(assignEmployeeCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(assignProjectCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
     public void execute_employeeIndexOutOfBounds_throwsException() {
         Index outOfBoundsIndex = Index.fromOneBased(999);
-        AssignEmployeeCommand assignEmployeeCommand =
-                new AssignEmployeeCommand(Index.fromOneBased(1),
+        AssignProjectCommand assignProjectCommand =
+                new AssignProjectCommand(Index.fromOneBased(1),
                         new ArrayList<>(Arrays.asList(outOfBoundsIndex)));
         assertThrows(CommandException.class, Messages.MESSAGE_INVALID_EMPLOYEE_DISPLAYED_INDEX, () ->
-                assignEmployeeCommand.execute(model));
+                assignProjectCommand.execute(model));
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/UnassignProjectCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UnassignProjectCommandTest.java
@@ -66,6 +66,10 @@ public class UnassignProjectCommandTest {
         expectedModel.setProject(projectToUnassign, editedProject);
 
         assertCommandSuccess(unassignProjectCommand, model, expectedMessage, expectedModel);
+
+        // Verify that the employees have been removed from the project in the model
+        Project projectInModel = expectedModel.getFilteredProjectList().get(INDEX_FIRST_PROJECT.getZeroBased());
+        assertTrue(projectInModel.employeeList.isEmpty());
     }
 
     @Test
@@ -99,6 +103,10 @@ public class UnassignProjectCommandTest {
 
         // Alice is already unassigned from project, so command should fail
         assertCommandFailure(unassignProjectCommand, model, expectedFailureMessage);
+
+        // Verify that Alice has been removed and Benson is still in the project
+        Project projectInModel = expectedModel.getFilteredProjectList().get(INDEX_FIRST_PROJECT.getZeroBased());
+        assertTrue(projectInModel.employeeList.contains(BENSON));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/UnassignProjectCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UnassignProjectCommandTest.java
@@ -1,0 +1,153 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_EMPLOYEE_DISPLAYED_INDEX;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_PROJECT_DISPLAYED_INDEX;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalEmployees.ALICE;
+import static seedu.address.testutil.TypicalEmployees.BENSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_EMPLOYEE;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PROJECT;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_EMPLOYEE;
+import static seedu.address.testutil.TypicalProjects.getTypicalTaskHub;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.project.Project;
+import seedu.address.testutil.ProjectBuilder;
+
+public class UnassignProjectCommandTest {
+
+    private Model model = new ModelManager(getTypicalTaskHub(), new UserPrefs());
+
+    @Test
+    public void constructor_nullProjectIndex_throwsNullPointerException() {
+        List<Index> validEmployeeIndexes = Arrays.asList(INDEX_FIRST_EMPLOYEE, INDEX_SECOND_EMPLOYEE);
+        assertThrows(NullPointerException.class, () ->
+                new UnassignProjectCommand(null, validEmployeeIndexes));
+    }
+
+    @Test
+    public void constructor_nullEmployeeIndexes_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () ->
+                new UnassignProjectCommand(INDEX_FIRST_PROJECT, null));
+    }
+
+    @Test
+    public void execute_validInputs_success() {
+        Project projectToUnassign = model.getFilteredProjectList().get(INDEX_FIRST_PROJECT.getZeroBased());
+        ProjectBuilder projectBuilder = new ProjectBuilder(projectToUnassign);
+
+        // Assign Alice and Benson employees to project
+        model.setProject(projectToUnassign, projectBuilder.withEmployees(ALICE, BENSON).build());
+
+        List<Index> employeeIndexes = Arrays.asList(INDEX_FIRST_EMPLOYEE, INDEX_SECOND_EMPLOYEE);
+
+        // Command to unassign Alice and Benson employees from project
+        UnassignProjectCommand unassignProjectCommand = new UnassignProjectCommand(INDEX_FIRST_PROJECT,
+                employeeIndexes);
+
+        Project editedProject = projectBuilder.withEmployees().build();
+        String expectedMessage = String.format(UnassignProjectCommand.MESSAGE_UNASSIGN_PROJECT_SUCCESS,
+                Messages.format(editedProject));
+
+        Model expectedModel = new ModelManager(getTypicalTaskHub(), new UserPrefs());
+        expectedModel.setProject(projectToUnassign, editedProject);
+
+        assertCommandSuccess(unassignProjectCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_repeatCommand_failure() {
+        Project projectToUnassign = model.getFilteredProjectList().get(INDEX_FIRST_PROJECT.getZeroBased());
+        ProjectBuilder projectBuilder = new ProjectBuilder(projectToUnassign);
+
+        // Assign Alice and Benson employees to project
+        model.setProject(projectToUnassign, projectBuilder.withEmployees(ALICE, BENSON).build());
+
+        List<Index> employeeIndexes = Arrays.asList(INDEX_FIRST_EMPLOYEE);
+
+        // Command to unassign Alice from project
+        UnassignProjectCommand unassignProjectCommand = new UnassignProjectCommand(INDEX_FIRST_PROJECT,
+                employeeIndexes);
+
+        // Expected project after command execution should only have Benson assigned
+        Project expectedProject = projectBuilder.withEmployees(BENSON).build();
+        String expectedSuccessMessage = String.format(UnassignProjectCommand.MESSAGE_UNASSIGN_PROJECT_SUCCESS,
+                Messages.format(expectedProject));
+
+        Model expectedModel = new ModelManager(getTypicalTaskHub(), new UserPrefs());
+        expectedModel.setProject(projectToUnassign, expectedProject);
+
+        // First time unassigning Alice from project
+        assertCommandSuccess(unassignProjectCommand, model, expectedSuccessMessage, expectedModel);
+
+        String expectedFailureMessage = String.format(UnassignProjectCommand.MESSAGE_UNASSIGN_PROJECT_FAILURE,
+                ALICE.getName(), INDEX_FIRST_EMPLOYEE.getOneBased(),
+                projectToUnassign.getNameString(), INDEX_FIRST_PROJECT.getOneBased());
+
+        // Alice is already unassigned from project, so command should fail
+        assertCommandFailure(unassignProjectCommand, model, expectedFailureMessage);
+    }
+
+    @Test
+    public void execute_invalidProjectIndex_throwsCommandException() {
+        List<Index> employeeIndexes = Arrays.asList(INDEX_FIRST_EMPLOYEE, INDEX_SECOND_EMPLOYEE);
+        UnassignProjectCommand unassignProjectCommand = new UnassignProjectCommand(Index.fromOneBased(999),
+                employeeIndexes);
+        assertCommandFailure(unassignProjectCommand, model, MESSAGE_INVALID_PROJECT_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_invalidEmployeeIndex_throwsCommandException() {
+        Project projectToUnassign = model.getFilteredProjectList().get(INDEX_FIRST_PROJECT.getZeroBased());
+        ProjectBuilder projectBuilder = new ProjectBuilder(projectToUnassign);
+
+        model.setProject(projectToUnassign, projectBuilder.withEmployees(ALICE, BENSON).build());
+
+        List<Index> employeeIndexes = Arrays.asList(INDEX_FIRST_EMPLOYEE, Index.fromOneBased(999));
+        UnassignProjectCommand unassignProjectCommand = new UnassignProjectCommand(INDEX_FIRST_PROJECT,
+                employeeIndexes);
+
+        assertCommandFailure(unassignProjectCommand, model, MESSAGE_INVALID_EMPLOYEE_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        final UnassignProjectCommand standardCommand = new UnassignProjectCommand(INDEX_FIRST_PROJECT,
+                Arrays.asList(INDEX_FIRST_EMPLOYEE, INDEX_SECOND_EMPLOYEE));
+
+        // same values -> returns true
+        UnassignProjectCommand commandWithSameValues = new UnassignProjectCommand(INDEX_FIRST_PROJECT,
+                Arrays.asList(INDEX_FIRST_EMPLOYEE, INDEX_SECOND_EMPLOYEE));
+        assertTrue(standardCommand.equals(commandWithSameValues));
+
+        // same object -> returns true
+        assertTrue(standardCommand.equals(standardCommand));
+
+        // null -> returns false
+        assertFalse(standardCommand.equals(null));
+
+        // different types -> returns false
+        assertFalse(standardCommand.equals(new ClearCommand()));
+
+        // different project index -> returns false
+        assertFalse(standardCommand.equals(new UnassignProjectCommand(INDEX_FIRST_PROJECT,
+                Arrays.asList(INDEX_FIRST_EMPLOYEE, Index.fromOneBased(3)))));
+
+        // different employee indexes -> returns false
+        assertFalse(standardCommand.equals(new UnassignProjectCommand(INDEX_FIRST_PROJECT,
+                Arrays.asList(INDEX_FIRST_EMPLOYEE, INDEX_SECOND_EMPLOYEE, Index.fromOneBased(3)))));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AssignProjectCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AssignProjectCommandParserTest.java
@@ -13,30 +13,30 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
-import seedu.address.logic.commands.AssignEmployeeCommand;
+import seedu.address.logic.commands.AssignProjectCommand;
 
-public class AssignEmployeeCommandParserTest {
-    private AssignEmployeeCommandParser parser = new AssignEmployeeCommandParser();
+public class AssignProjectCommandParserTest {
+    private AssignProjectCommandParser parser = new AssignProjectCommandParser();
 
     @Test
     public void parse_indexSpecified_success() {
         Index targetIndex = INDEX_FIRST_EMPLOYEE;
         String userInput = " " + PREFIX_PROJECT + targetIndex.getOneBased() + " "
                             + PREFIX_EMPLOYEE + targetIndex.getOneBased();
-        AssignEmployeeCommand command = new AssignEmployeeCommand(targetIndex,
+        AssignProjectCommand command = new AssignProjectCommand(targetIndex,
                                         new ArrayList<>(Arrays.asList(targetIndex)));
         assertParseSuccess(parser, userInput, command);
     }
 
     @Test
     public void parse_missingCompulsoryField_failure() {
-        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AssignEmployeeCommand.MESSAGE_USAGE);
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AssignProjectCommand.MESSAGE_USAGE);
 
         // no parameters
-        assertParseFailure(parser, AssignEmployeeCommand.COMMAND_WORD, expectedMessage);
+        assertParseFailure(parser, AssignProjectCommand.COMMAND_WORD, expectedMessage);
 
         // no employee index
-        assertParseFailure(parser, AssignEmployeeCommand.COMMAND_WORD + " " + PREFIX_PROJECT
+        assertParseFailure(parser, AssignProjectCommand.COMMAND_WORD + " " + PREFIX_PROJECT
                                         + INDEX_FIRST_EMPLOYEE.toString(), expectedMessage);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/MarkProjectCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/MarkProjectCommandParserTest.java
@@ -1,8 +1,8 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -30,7 +30,6 @@ public class MarkProjectCommandParserTest {
     @Test
     public void parse_invalidIndex_failure() {
         String userInput = "a";
-        assertParseFailure(parser, userInput, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                MarkProjectCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, userInput, String.format(MESSAGE_INVALID_INDEX, userInput));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -52,8 +52,7 @@ public class ParserUtilTest {
     @Test
     public void parseIndex_negativeInput_throwsParseException() {
         assertThrows(ParseException.class,
-                String.format(MESSAGE_INVALID_INDEX, "-1"),
-                () -> ParserUtil.parseIndex("-1"));
+                String.format(MESSAGE_INVALID_INDEX, "-1"), () -> ParserUtil.parseIndex("-1"));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -50,9 +50,10 @@ public class ParserUtilTest {
     }
 
     @Test
-    public void parseIndex_outOfRangeInput_throwsParseException() {
-        assertThrows(ParseException.class, MESSAGE_INVALID_INDEX, ()
-            -> ParserUtil.parseIndex(Long.toString(Integer.MAX_VALUE + 1)));
+    public void parseIndex_negativeInput_throwsParseException() {
+        assertThrows(ParseException.class,
+                String.format(MESSAGE_INVALID_INDEX, "-1"),
+                () -> ParserUtil.parseIndex("-1"));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/TaskHubParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/TaskHubParserTest.java
@@ -11,6 +11,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PROJECT;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_EMPLOYEE;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PROJECT;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_EMPLOYEE;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PROJECT;
 import static seedu.address.testutil.TypicalTasks.ALPHA_TASK;
 
@@ -41,6 +42,7 @@ import seedu.address.logic.commands.ListProjectCommand;
 import seedu.address.logic.commands.MarkProjectCommand;
 import seedu.address.logic.commands.PriorityProjectCommand;
 import seedu.address.logic.commands.ProjectDeadlineCommand;
+import seedu.address.logic.commands.UnassignProjectCommand;
 import seedu.address.logic.commands.UnmarkProjectCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.employee.Employee;
@@ -141,8 +143,20 @@ public class TaskHubParserTest {
                 (AssignProjectCommand) parser.parseCommand(AssignProjectCommand.COMMAND_WORD + " "
                  + PREFIX_PROJECT + INDEX_FIRST_EMPLOYEE.getOneBased() + " " + PREFIX_EMPLOYEE
                         + INDEX_FIRST_EMPLOYEE.getOneBased());
-        assertEquals(new AssignProjectCommand(INDEX_FIRST_EMPLOYEE,
+        assertEquals(new AssignProjectCommand(INDEX_FIRST_PROJECT,
                                                 new ArrayList<>(Arrays.asList(INDEX_FIRST_EMPLOYEE))), command);
+    }
+
+    @Test
+    public void parseCommand_unassignEmployeeFromProject() throws Exception {
+        UnassignProjectCommand command =
+                (UnassignProjectCommand) parser.parseCommand(UnassignProjectCommand.COMMAND_WORD + " "
+                + PREFIX_PROJECT + INDEX_FIRST_PROJECT.getOneBased() + " "
+                + PREFIX_EMPLOYEE + INDEX_FIRST_EMPLOYEE.getOneBased() + " "
+                + INDEX_SECOND_EMPLOYEE.getOneBased());
+        assertEquals(new UnassignProjectCommand(INDEX_FIRST_PROJECT,
+                     new ArrayList<>(Arrays.asList(INDEX_FIRST_EMPLOYEE, INDEX_SECOND_EMPLOYEE))),
+                     command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/TaskHubParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/TaskHubParserTest.java
@@ -25,7 +25,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.AddEmployeeCommand;
 import seedu.address.logic.commands.AddProjectCommand;
 import seedu.address.logic.commands.AddTaskCommand;
-import seedu.address.logic.commands.AssignEmployeeCommand;
+import seedu.address.logic.commands.AssignProjectCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.DeleteEmployeeCommand;
 import seedu.address.logic.commands.DeleteProjectCommand;
@@ -137,11 +137,11 @@ public class TaskHubParserTest {
 
     @Test
     public void parseCommand_assignEmployeeToProject() throws Exception {
-        AssignEmployeeCommand command =
-                (AssignEmployeeCommand) parser.parseCommand(AssignEmployeeCommand.COMMAND_WORD + " "
+        AssignProjectCommand command =
+                (AssignProjectCommand) parser.parseCommand(AssignProjectCommand.COMMAND_WORD + " "
                  + PREFIX_PROJECT + INDEX_FIRST_EMPLOYEE.getOneBased() + " " + PREFIX_EMPLOYEE
                         + INDEX_FIRST_EMPLOYEE.getOneBased());
-        assertEquals(new AssignEmployeeCommand(INDEX_FIRST_EMPLOYEE,
+        assertEquals(new AssignProjectCommand(INDEX_FIRST_EMPLOYEE,
                                                 new ArrayList<>(Arrays.asList(INDEX_FIRST_EMPLOYEE))), command);
     }
 

--- a/src/test/java/seedu/address/logic/parser/UnassignProjectCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UnassignProjectCommandParserTest.java
@@ -5,6 +5,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_EMPLOYEE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PROJECT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_EMPLOYEE;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PROJECT;
 import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_EMPLOYEE;
@@ -46,13 +47,13 @@ public class UnassignProjectCommandParserTest {
     @Test
     public void parse_invalidIndexes_failure() {
         String args = " " + PREFIX_PROJECT + "abc " + PREFIX_EMPLOYEE + "2 3 4";
-        assertParseFailure(parser, args, ParserUtil.MESSAGE_INVALID_INDEX);
+        assertParseFailure(parser, args, String.format(MESSAGE_INVALID_INDEX, "abc"));
     }
 
     @Test
     public void parse_noIndexes_failure() {
         String args = " " + PREFIX_PROJECT + "1 " + PREFIX_EMPLOYEE;
-        assertParseFailure(parser, args, ParserUtil.MESSAGE_INVALID_INDEX);
+        assertParseFailure(parser, args, String.format(MESSAGE_INVALID_INDEX, "<empty>"));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/UnassignProjectCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UnassignProjectCommandParserTest.java
@@ -1,0 +1,63 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMPLOYEE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PROJECT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_EMPLOYEE;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PROJECT;
+import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_EMPLOYEE;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.UnassignProjectCommand;
+
+
+public class UnassignProjectCommandParserTest {
+
+    private UnassignProjectCommandParser parser = new UnassignProjectCommandParser();
+
+    @Test
+    public void parse_validArgs_success() {
+        String args = " " + PREFIX_PROJECT + "1 " + PREFIX_EMPLOYEE + "1 3";
+        UnassignProjectCommand expectedCommand = new UnassignProjectCommand(
+                INDEX_FIRST_PROJECT,
+                List.of(INDEX_FIRST_EMPLOYEE, INDEX_THIRD_EMPLOYEE));
+        assertParseSuccess(parser, args, expectedCommand);
+    }
+
+    @Test
+    public void parse_missingProjectPrefix_failure() {
+        String args = " 1 " + PREFIX_EMPLOYEE + "2 3 4";
+        assertParseFailure(parser, args, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                UnassignProjectCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_missingEmployeePrefix_failure() {
+        String args = " " + PREFIX_PROJECT + "1 2 3 4";
+        assertParseFailure(parser, args, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                UnassignProjectCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_invalidIndexes_failure() {
+        String args = " " + PREFIX_PROJECT + "abc " + PREFIX_EMPLOYEE + "2 3 4";
+        assertParseFailure(parser, args, ParserUtil.MESSAGE_INVALID_INDEX);
+    }
+
+    @Test
+    public void parse_noIndexes_failure() {
+        String args = " " + PREFIX_PROJECT + "1 " + PREFIX_EMPLOYEE;
+        assertParseFailure(parser, args, ParserUtil.MESSAGE_INVALID_INDEX);
+    }
+
+    @Test
+    public void parse_repeatedIndexes_failure() {
+        String args = " " + PREFIX_PROJECT + "1 " + PREFIX_EMPLOYEE + "1 1";
+        assertParseFailure(parser, args, String.format(ParserUtil.MESSAGE_DUPLICATE_INDEX, "1"));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/UnmarkProjectCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UnmarkProjectCommandParserTest.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -30,7 +31,6 @@ public class UnmarkProjectCommandParserTest {
     @Test
     public void parse_invalidIndex_failure() {
         String userInput = "a";
-        assertParseFailure(parser, userInput, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                UnmarkProjectCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, userInput, String.format(MESSAGE_INVALID_INDEX, userInput));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/UnmarkProjectCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UnmarkProjectCommandParserTest.java
@@ -1,6 +1,5 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;


### PR DESCRIPTION
Closes #145 
Fixes #146

1. New command implemented:
    - Command: `unassignP`
    - Format: `unassignP pr/PROJECT_INDEX em/EMPLOYEE_INDEX [MORE_EMPLOYEE_INDEXES]`
        - The employee indexes here refer to the indexes shown in the Employee panel, and not in the Project panel. An error message is shown when the user tries to unassign an employee that is not in a project. This is to standardize with `assignP` which also refers to employee indexes in the Employee panel.

    - Example usage: `unassignP pr/1 em/1 2 3`
    - Example error message when trying to unassign an employee that is not assigned to the specified project:
        - Command: `unassignP pr/1 em/2`
        - `The following employee is not in the specified project.`  
         `Employee: Chandan (Index: 2)`  
         `Project: Web Redesign (Index: 1)`  
        `Please check the project and employee index again. Using the findP command to isolate the project and it's employees may be useful.`

2. Modified command word: `assignE` -> `assignP`
3. Refactored files and variable names in line with point 2: 
`AssignEmployeeCommand` -> `AssignProjectCommand`
`AssignEmployeeCommandParser` -> `AssignProjectCommandParser`
4. Fixed bug where `ParserUtil#parseIndexes(String indexes)` allows repeated indexes. A "duplicate index" error message is shown when repeated indexes are present. This bug is mentioned in #146.
    - While fixing this bug, I noticed that some commands do not give this specific "duplicate index" error message, and just outputs a generic "Invalid Command Format" error message. Some of these commands include: ~~`markP/unmarkP` (@aslam341)~~, `markT`/`unmarkT` (@Chandan8186) and `assignP` (@antonTan96). However, there are some commands that correctly outputs the specific error message, and this includes `addP` and `unassignP`.
    - This bug occurs when throwing `ParseException` at the wrong place and/or with the wrong message.
    - This has been fixed for `markP` and `unmarkP` in this PR.
6. Improved String representation of project in `Messages#format(Project project)`