### PR TITLE
Implement deleteT

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -22,6 +22,7 @@ public class Messages {
     public static final String MESSAGE_INVALID_TASK_DISPLAYED_INDEX = "The task index provided is invalid";
     public static final String MESSAGE_NO_PROJECT_TO_ADD_TASK = "You don't have any projects to add tasks to.\n "
             + "Try creating a project with addP!";
+    public static final String MESSAGE_NO_PROJECT_TO_DELETE_TASK = "You don't have any projects to delete tasks from.";
     public static final String MESSAGE_EMPLOYEES_LISTED_OVERVIEW = "%1$d employee(s) and their project(s) listed!";
     public static final String MESSAGE_PROJECTS_LISTED_OVERVIEW = "%1$d project(s) and their employee(s) listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =

--- a/src/main/java/seedu/address/logic/commands/AddTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddTaskCommand.java
@@ -28,12 +28,12 @@ public class AddTaskCommand extends Command {
             + "Parameters: "
             + PREFIX_NAME + "TASK_NAME\n"
             + PREFIX_PROJECT + "PROJECT_INDEX\n"
-            + PREFIX_DEADLINE + "TASK_DEADLINE{yyyy-MM-dd HHmm}\n\n"
+            + PREFIX_DEADLINE + "TASK_DEADLINE{dd-MM-yyyy HHmm}\n\n"
             + "Example: "
             + COMMAND_WORD + " "
-            + PREFIX_NAME + "name of task"
+            + PREFIX_NAME + "name of task "
             + PREFIX_PROJECT + "1 "
-            + PREFIX_DEADLINE + "2023-11-31 2359";
+            + PREFIX_DEADLINE + "11-11-2023 2359";
 
     private final Task task;
     private final Index projectIndex;

--- a/src/main/java/seedu/address/logic/commands/DeleteTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteTaskCommand.java
@@ -1,0 +1,112 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PROJECT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TASK;
+
+import java.util.List;
+import java.util.logging.Logger;
+
+import seedu.address.commons.core.LogsCenter;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.project.Project;
+import seedu.address.model.task.TaskList;
+
+
+
+/**
+ * Deletes a task from an existing project in TaskHub.
+ */
+public class DeleteTaskCommand extends Command {
+
+    public static final String COMMAND_WORD = "deleteT";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Deletes (a) task(s) from a project in TaskHub.\n"
+            + "Parameters: " + PREFIX_PROJECT + "PROJECT_INDEX " + PREFIX_TASK + "TASK_INDEXES\n"
+            + "PROJECT_INDEX must be one positive integer and "
+            + "TASK_INDEXES must be one or more positive integers, separated by a space between each INDEX\n"
+            + "Example: " + COMMAND_WORD + " " + PREFIX_PROJECT + "2 " + PREFIX_TASK + "1 2 4";
+
+    public static final String MESSAGE_TASKS_DELETED_SUCCESSFULLY =
+            "%d task(s) deleted from the project: %s";
+    private static final Logger logger = LogsCenter.getLogger(DeleteTaskCommand.class);
+    private final Index projectIndex;
+    private String projectName;
+    private final List<Index> taskIndexes;
+
+    /**
+     * Creates a DeleteTaskCommand to delete the specified tasks from the specified project.
+     * @param projectIndex
+     * @param taskIndexes
+     */
+    public DeleteTaskCommand(Index projectIndex, List<Index> taskIndexes) {
+        requireAllNonNull(taskIndexes);
+        assert taskIndexes.size() > 0;
+        this.projectIndex = projectIndex;
+        this.taskIndexes = taskIndexes;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        List<Project> lastShownProjectList = model.getFilteredProjectList();
+
+        if (lastShownProjectList.size() == 0) {
+            throw new CommandException(Messages.MESSAGE_NO_PROJECT_TO_DELETE_TASK);
+        } else if (projectIndex.getZeroBased() >= lastShownProjectList.size()
+            // Check if project index is valid first
+            || projectIndex.getZeroBased() < 0) {
+            logger.warning("Invalid project index: " + projectIndex.getOneBased());
+            throw new CommandException(Messages.MESSAGE_INVALID_PROJECT_DISPLAYED_INDEX);
+        }
+
+        Project targetProject = lastShownProjectList.get(projectIndex.getZeroBased());
+        TaskList lastShownTaskList = targetProject.getTasks();
+
+        // Delete all tasks from targetProject
+        for (Index taskIndex : taskIndexes) {
+            // Check if task index is valid first
+            if (taskIndex.getZeroBased() >= lastShownTaskList.getSize()
+                    || taskIndex.getZeroBased() < 0) {
+                logger.warning("Invalid task index: " + taskIndex.getOneBased());
+                throw new CommandException(Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
+            }
+            lastShownTaskList.remove(taskIndex);
+        }
+
+        // Create new project with updated tasks
+        Project updatedProject = new Project(targetProject.getNameString(), targetProject.getEmployees(),
+                lastShownTaskList, targetProject.getProjectPriority(),
+                targetProject.getDeadline(), targetProject.getCompletionStatus());
+
+        projectName = updatedProject.getNameString();
+
+        model.setProject(targetProject, updatedProject);
+        model.updateFilteredProjectList(Model.PREDICATE_SHOW_ALL_PROJECTS);
+        return new CommandResult(generateSuccessMessage());
+    }
+
+    /**
+     * Generates a command execution success message based on whether all the tasks were deleted.
+     */
+    private String generateSuccessMessage() {
+        return String.format(MESSAGE_TASKS_DELETED_SUCCESSFULLY, taskIndexes.size(), projectName);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof DeleteTaskCommand)) {
+            return false;
+        }
+
+        DeleteTaskCommand otherCommand = (DeleteTaskCommand) other;
+        return projectIndex.equals(otherCommand.projectIndex) && taskIndexes.equals(otherCommand.taskIndexes);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/DeleteTaskCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteTaskCommandParser.java
@@ -1,0 +1,58 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PROJECT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TASK;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.DeleteTaskCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+
+
+/**
+ * Parses input arguments and creates a new DeleteTaskCommand object
+ */
+public class DeleteTaskCommandParser implements Parser<DeleteTaskCommand> {
+
+    @Override
+    public DeleteTaskCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        assert args != null;
+
+        // check for duplicates
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_PROJECT, PREFIX_TASK);
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_PROJECT);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_PROJECT, PREFIX_TASK)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteTaskCommand.MESSAGE_USAGE));
+        }
+
+        try {
+            // get project and task indexes
+            Index projectIndex = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_PROJECT).get());
+            List<Index> taskIndexes = ParserUtil.parseIndexes(argMultimap.getValue(PREFIX_TASK).get());
+            assert taskIndexes.size() > 0;
+            taskIndexes.sort((a, b) -> b.getZeroBased() - a.getZeroBased());
+
+            return new DeleteTaskCommand(projectIndex, taskIndexes);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteTaskCommand.MESSAGE_USAGE), pe);
+        }
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/DeleteTaskCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteTaskCommandParser.java
@@ -27,7 +27,7 @@ public class DeleteTaskCommandParser implements Parser<DeleteTaskCommand> {
         // check for duplicates
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_PROJECT, PREFIX_TASK);
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_PROJECT);
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_PROJECT, PREFIX_TASK);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_PROJECT, PREFIX_TASK)
                 || !argMultimap.getPreamble().isEmpty()) {

--- a/src/main/java/seedu/address/logic/parser/MarkTaskCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/MarkTaskCommandParser.java
@@ -26,7 +26,7 @@ public class MarkTaskCommandParser implements Parser<MarkTaskCommand> {
         // check for duplicates
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_PROJECT, PREFIX_TASK);
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_PROJECT);
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_PROJECT, PREFIX_TASK);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_PROJECT, PREFIX_TASK)
                 || !argMultimap.getPreamble().isEmpty()) {

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -155,7 +155,7 @@ public class ParserUtil {
         if (!Task.isValidDateTime(deadlineString)) {
             throw new ParseException(Task.MESSAGE_CONSTRAINTS);
         }
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HHmm");
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd-MM-yyyy HHmm");
         LocalDateTime parsedDateTime = LocalDateTime.parse(trimmedDeadlineString, formatter);
         return parsedDateTime;
     }

--- a/src/main/java/seedu/address/logic/parser/TaskHubParser.java
+++ b/src/main/java/seedu/address/logic/parser/TaskHubParser.java
@@ -16,6 +16,7 @@ import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteEmployeeCommand;
 import seedu.address.logic.commands.DeleteProjectCommand;
+import seedu.address.logic.commands.DeleteTaskCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindEmployeeCommand;
@@ -102,6 +103,9 @@ public class TaskHubParser {
 
         case AddTaskCommand.COMMAND_WORD:
             return new AddTaskCommandParser().parse(arguments);
+
+        case DeleteTaskCommand.COMMAND_WORD:
+            return new DeleteTaskCommandParser().parse(arguments);
 
         case ListEmployeeAndProjectCommand.COMMAND_WORD:
             return new ListEmployeeAndProjectCommand();

--- a/src/main/java/seedu/address/logic/parser/UnmarkTaskCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UnmarkTaskCommandParser.java
@@ -25,7 +25,7 @@ public class UnmarkTaskCommandParser implements Parser<UnmarkTaskCommand> {
         // check for duplicates
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_PROJECT, PREFIX_TASK);
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_PROJECT);
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_PROJECT, PREFIX_TASK);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_PROJECT, PREFIX_TASK)
                 || !argMultimap.getPreamble().isEmpty()) {

--- a/src/main/java/seedu/address/model/task/Task.java
+++ b/src/main/java/seedu/address/model/task/Task.java
@@ -13,8 +13,8 @@ import seedu.address.model.employee.Employee;
 public class Task {
 
     public static final String MESSAGE_CONSTRAINTS = "You must enter a name for a task!\n"
-            + "You must also enter a deadline, which should be in the format: yyyy-mm-dd HHmm\n "
-            + "e.g., addT n/name pr/1 d/2023-11-11 2359";
+            + "You must also enter a deadline, which should be in the format: dd-mm-yyyy HHmm\n "
+            + "e.g., addT n/name pr/1 d/11-11-2023 2359";
 
     /**
      * The first character must not be a whitespace,

--- a/src/main/java/seedu/address/model/task/Task.java
+++ b/src/main/java/seedu/address/model/task/Task.java
@@ -103,17 +103,17 @@ public class Task {
         return completionString + " | "
                                     + this.name + " | "
                                         + this.employee + " | "
-                                            + DateTimeFormatter.ofPattern("yyyy-MM-dd HHmm").format(this.deadline);
+                                            + DateTimeFormatter.ofPattern("dd-MM-yyyy HHmm").format(this.deadline);
     }
 
     /**
-     * Determines if a string is of the format "yyyy-MM-dd HHmm" i.e., a valid LocalDateTime object.
+     * Determines if a string is of the format "dd-MM-yyyy HHmm" i.e., a valid LocalDateTime object.
      *
      * @param input The string to be examined.
      * @return A boolean value which tells us if the string represents a LocalDate.
      */
     public static boolean isValidDateTime(String input) {
-        DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyy-MM-dd HHmm");
+        DateTimeFormatter dtf = DateTimeFormatter.ofPattern("dd-MM-yyyy HHmm");
         try {
             LocalDateTime.parse(input, dtf);
             return true; // Parsing success: Valid date/time

--- a/src/main/java/seedu/address/model/task/TaskList.java
+++ b/src/main/java/seedu/address/model/task/TaskList.java
@@ -40,6 +40,18 @@ public class TaskList implements Iterable<Task> {
             throw new TaskNotFoundException();
         }
     }
+    /**
+     * Removes the Task at index i from the list.
+     * The Task must exist in the list.
+     */
+    public void remove(Index i) {
+        requireNonNull(i);
+        try {
+            internalList.remove(i.getZeroBased());
+        } catch (UnsupportedOperationException | IndexOutOfBoundsException e) {
+            throw new TaskNotFoundException();
+        }
+    }
 
     public void setTasks(TaskList replacement) {
         requireNonNull(replacement);

--- a/src/main/java/seedu/address/ui/ProjectCard.java
+++ b/src/main/java/seedu/address/ui/ProjectCard.java
@@ -3,6 +3,7 @@ package seedu.address.ui;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 
+import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.Label;
@@ -10,6 +11,7 @@ import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
 import seedu.address.model.project.Project;
+import seedu.address.model.task.Task;
 
 /**
  * An UI component that displays information of a {@code Project}.
@@ -78,9 +80,14 @@ public class ProjectCard extends UiPart<Region> {
             priority.setStyle("-fx-text-fill: red;");
         }
 
-        TaskListPanel taskListPanel = new TaskListPanel(project.getTasks().asUnmodifiableObservableList());
-        taskListPlaceholder.getChildren().add(taskListPanel.getRoot());
+        ObservableList<Task> taskObservableList = project.getTasks().asUnmodifiableObservableList();
+        TaskListPanel taskListPanel = new TaskListPanel(taskObservableList);
 
+        if (taskObservableList.isEmpty()) {
+            taskListPlaceholder.setVisible(false);
+        } else {
+            taskListPlaceholder.getChildren().add(taskListPanel.getRoot());
+        }
         // Set the deadline
         if (project.getDeadline().value.isEmpty()) {
             deadline.setText("No deadline set");

--- a/src/test/java/seedu/address/logic/commands/AddTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddTaskCommandTest.java
@@ -1,39 +1,26 @@
 package seedu.address.logic.commands;
 
-import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalEmployees.ALICE;
 import static seedu.address.testutil.TypicalProjects.ALPHA;
 import static seedu.address.testutil.TypicalTasks.ALPHA_TASK;
 import static seedu.address.testutil.TypicalTasks.BETA_TASK;
 
-import java.nio.file.Path;
-import java.util.function.Predicate;
-
 import org.junit.jupiter.api.Test;
 
-import javafx.collections.FXCollections;
-import javafx.collections.ObservableList;
-import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.ParserUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.Model;
-import seedu.address.model.ReadOnlyTaskHub;
-import seedu.address.model.ReadOnlyUserPrefs;
-import seedu.address.model.employee.Employee;
-import seedu.address.model.project.Project;
 import seedu.address.model.task.Task;
+import seedu.address.testutil.ModelStubWithEmptyProjectList;
+import seedu.address.testutil.ModelStubWithProjectAndEmployee;
 import seedu.address.testutil.TaskBuilder;
-
 public class AddTaskCommandTest {
-
     @Test
     public void constructor_nullTask_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> new AddTaskCommand(null, null));
@@ -99,209 +86,6 @@ public class AddTaskCommandTest {
         AddTaskCommand addTaskCommand = new AddTaskCommand(ALPHA_TASK, ParserUtil.parseIndex("1"));
         String expected = AddTaskCommand.class.getCanonicalName() + "{toAdd=" + ALPHA_TASK + "}";
         assertEquals(expected, addTaskCommand.toString());
-    }
-
-    /**
-     * A default model stub that have all the methods failing.
-     */
-    private class ModelStub implements Model {
-        @Override
-        public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ReadOnlyUserPrefs getUserPrefs() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public GuiSettings getGuiSettings() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setGuiSettings(GuiSettings guiSettings) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public Path getTaskHubFilePath() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setTaskHubFilePath(Path taskHubFilePath) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void addEmployee(Employee employee) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void addProject(Project project) {
-            throw new AssertionError("This method should not be called.");
-        }
-        @Override
-        public void addTask(Task task) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setTaskHub(ReadOnlyTaskHub newData) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ReadOnlyTaskHub getTaskHub() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public boolean hasEmployee(Employee employee) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public boolean hasProject(Project project) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void deleteEmployee(Employee target) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void deleteProject(Project project) {
-            throw new AssertionError("This method should not be called.");
-        }
-        @Override
-        public void deleteTask(Task task) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setEmployee(Employee target, Employee editedEmployee) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ObservableList<Employee> getFilteredEmployeeList() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ObservableList<Project> getFilteredProjectList() {
-
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ObservableList<Task> getFilteredTaskList() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-
-        @Override
-        public void updateFilteredEmployeeList(Predicate<Employee> predicate) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setProject(Project projectToEdit, Project editedProject) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void updateFilteredProjectList(Predicate<Project> predicate) {
-            throw new AssertionError("This method should not be called.");
-        }
-        @Override
-        public void updateFilteredTaskList(Predicate<Task> predicate) {
-            throw new AssertionError("This method should not be called.");
-        }
-    }
-
-    private class ModelStubWithProjectAndEmployee extends ModelStub {
-        private Project project;
-        private Employee employee;
-
-        ModelStubWithProjectAndEmployee(Project project, Employee employee) {
-            requireAllNonNull(project, employee);
-            this.employee = employee;
-            this.project = project;
-        }
-
-        @Override
-        public ObservableList<Project> getFilteredProjectList() {
-            ObservableList<Project> filteredList = FXCollections.observableArrayList();
-            filteredList.add(project); // Add the project to the list
-            return filteredList;
-        }
-        @Override
-        public boolean hasProject(Project project) {
-            requireNonNull(project);
-            return this.project.isSameProject(project);
-        }
-        @Override
-        public void updateFilteredProjectList(Predicate<Project> predicate) {
-            // do nothing - no need to update the model stub with just one project
-        }
-        @Override
-        public void setProject(Project project, Project editedProject) {
-            requireAllNonNull(project, editedProject);
-            this.project = editedProject;
-
-        }
-        @Override
-        public void addTask(Task task) {
-            this.project.addTask(task);
-
-        }
-
-
-        @Override
-        public ObservableList<Employee> getFilteredEmployeeList() {
-            ObservableList<Employee> filteredList = FXCollections.observableArrayList();
-            filteredList.add(employee); // Add the employee to the list
-            return filteredList;
-        }
-    }
-    private class ModelStubWithEmptyProjectList extends ModelStub {
-
-
-        @Override
-        public ObservableList<Project> getFilteredProjectList() {
-            ObservableList<Project> filteredList = FXCollections.observableArrayList();
-            return filteredList;
-        }
-        @Override
-        public boolean hasProject(Project project) {
-            requireNonNull(project);
-            return false;
-        }
-        @Override
-        public void updateFilteredProjectList(Predicate<Project> predicate) {
-            // do nothing - no need to update the model stub with just one project
-        }
-        @Override
-        public void setProject(Project project, Project editedProject) {
-            requireAllNonNull(project, editedProject);
-        }
-        @Override
-        public void addTask(Task task) {
-            // do nothing
-        }
-
-
-        @Override
-        public ObservableList<Employee> getFilteredEmployeeList() {
-            ObservableList<Employee> filteredList = FXCollections.observableArrayList();
-            return filteredList;
-        }
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -52,7 +52,7 @@ public class CommandTestUtil {
 
     // Task valid fields
 
-    public static final String VALID_DEADLINE_TASK = "2023-11-11 2359";
+    public static final String VALID_DEADLINE_TASK = "11-11-2023 2359";
     public static final String VALID_NAME_TASK = "Read Book";
     public static final String VALID_PROJECT_INDEX_TASK = "1";
 

--- a/src/test/java/seedu/address/logic/commands/DeleteTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteTaskCommandTest.java
@@ -1,0 +1,109 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalEmployees.ALICE;
+import static seedu.address.testutil.TypicalProjects.ALPHA;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.parser.ParserUtil;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.testutil.ModelStubWithEmptyProjectList;
+import seedu.address.testutil.ModelStubWithProjectAndEmployee;
+
+
+
+public class DeleteTaskCommandTest {
+    @Test
+    public void constructor_nullTask_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new DeleteTaskCommand(null, null));
+    }
+
+    @Test
+    public void execute_deleteTaskOne_successful() throws Exception {
+        // ALPHA contains ALPHA_TASK
+        ModelStubWithProjectAndEmployee modelStub = new ModelStubWithProjectAndEmployee(ALPHA, ALICE);
+        Index projectIndex = ParserUtil.parseIndex("1");
+        Index taskIndex = ParserUtil.parseIndex("1");
+        List<Index> taskIndexes = new ArrayList<>();
+        taskIndexes.add(taskIndex);
+        CommandResult commandResult = new DeleteTaskCommand(projectIndex, taskIndexes).execute(modelStub);
+        assertEquals(String.format(DeleteTaskCommand.MESSAGE_TASKS_DELETED_SUCCESSFULLY,
+                                   taskIndexes.size(), ALPHA.getNameString()),
+                    commandResult.getFeedbackToUser());
+    }
+    @Test
+    public void execute_deleteTaskNoExistingProject_throwsCommandException() throws Exception {
+        ModelStubWithEmptyProjectList modelStub = new ModelStubWithEmptyProjectList();
+        Index projectIndex = ParserUtil.parseIndex("1");
+        Index taskIndex = ParserUtil.parseIndex("1");
+        List<Index> taskIndexes = new ArrayList<>();
+        taskIndexes.add(taskIndex);
+        DeleteTaskCommand deleteTaskCommand = new DeleteTaskCommand(projectIndex,
+                taskIndexes);
+        assertThrows(CommandException.class, Messages.MESSAGE_NO_PROJECT_TO_DELETE_TASK, () ->
+                deleteTaskCommand.execute(modelStub));
+    }
+
+
+    @Test
+    public void execute_deleteTaskInvalidProjectIndex_throwsCommandException() throws Exception {
+        ModelStubWithProjectAndEmployee modelStub = new ModelStubWithProjectAndEmployee(ALPHA, ALICE);
+        Index projectIndex = ParserUtil.parseIndex("50");
+        Index taskIndex = ParserUtil.parseIndex("1");
+        List<Index> taskIndexes = new ArrayList<>();
+        taskIndexes.add(taskIndex);
+        DeleteTaskCommand deleteTaskCommand = new DeleteTaskCommand(projectIndex,
+                                                                    taskIndexes);
+        assertThrows(CommandException.class, Messages.MESSAGE_INVALID_PROJECT_DISPLAYED_INDEX, () ->
+                deleteTaskCommand.execute(modelStub));
+    }
+
+    @Test
+    public void execute_deleteTaskInvalidTaskIndex_throwsCommandException() throws Exception {
+        ModelStubWithProjectAndEmployee modelStub = new ModelStubWithProjectAndEmployee(ALPHA, ALICE);
+        Index projectIndex = ParserUtil.parseIndex("1");
+        Index taskIndex = ParserUtil.parseIndex("50");
+        List<Index> taskIndexes = new ArrayList<>();
+        taskIndexes.add(taskIndex);
+        DeleteTaskCommand deleteTaskCommand = new DeleteTaskCommand(projectIndex,
+                                                                    taskIndexes);
+        assertThrows(CommandException.class, Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX, () ->
+                deleteTaskCommand.execute(modelStub));
+    }
+    @Test
+    public void equals() throws ParseException {
+        Index projectIndex = ParserUtil.parseIndex("1");
+        Index projectIndexTwo = ParserUtil.parseIndex("2");
+
+        Index taskIndex = ParserUtil.parseIndex("1");
+        List<Index> taskIndexes = new ArrayList<>();
+        taskIndexes.add(taskIndex);
+        DeleteTaskCommand deleteCommandV1 = new DeleteTaskCommand(projectIndex, taskIndexes);
+        DeleteTaskCommand deleteCommandV1Copy = new DeleteTaskCommand(projectIndex, taskIndexes);
+        DeleteTaskCommand deleteCommandV2 = new DeleteTaskCommand(projectIndexTwo, taskIndexes);
+
+        // same exact command -> returns true
+        assertTrue(deleteCommandV1.equals(deleteCommandV1));
+        // same indexes for both projects and tasks -> returns true
+        assertTrue(deleteCommandV1.equals(deleteCommandV1Copy));
+
+        // different types -> returns false
+        assertFalse(deleteCommandV1.equals(1));
+
+        // different projectIndexes -> returns false
+        assertFalse(deleteCommandV1.equals(1));
+
+        // null -> returns false
+        assertFalse(deleteCommandV1.equals(null));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/DeleteTaskCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteTaskCommandParserTest.java
@@ -1,0 +1,54 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.DeleteTaskCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+
+
+public class DeleteTaskCommandParserTest {
+
+    private DeleteTaskCommandParser parser = new DeleteTaskCommandParser();
+
+    @Test
+    public void parse_validProjectAndTaskIndexes_success() throws ParseException {
+        Index projectIndex = Index.fromOneBased(2);
+        List<Index> taskIndexes = new ArrayList<>();
+        taskIndexes.add(Index.fromOneBased(2));
+        taskIndexes.add(Index.fromOneBased(1));
+        taskIndexes.sort((a, b) -> b.getZeroBased() - a.getZeroBased());
+        DeleteTaskCommand expectedCommand = new DeleteTaskCommand(projectIndex, taskIndexes);
+        String userInput = " pr/2 t/1 2";
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_validProjectAndInvalidTaskIndexes_failure() {
+        String userInput = " pr/1 t/0 2";
+        assertParseFailure(parser, userInput, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                DeleteTaskCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_invalidProjectAndValidTaskIndexes_failure() {
+        String userInput = " pr/0 t/1 2";
+        assertParseFailure(parser, userInput, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                DeleteTaskCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_invalidInputFormat_failure() {
+        String userInput = " somerandomtext$#";
+        assertParseFailure(parser, userInput, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                DeleteTaskCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/TaskHubParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/TaskHubParserTest.java
@@ -30,6 +30,7 @@ import seedu.address.logic.commands.AssignEmployeeCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.DeleteEmployeeCommand;
 import seedu.address.logic.commands.DeleteProjectCommand;
+import seedu.address.logic.commands.DeleteTaskCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditEmployeeDescriptor;
 import seedu.address.logic.commands.ExitCommand;
@@ -238,8 +239,23 @@ public class TaskHubParserTest {
         AddTaskCommand command = (AddTaskCommand) parser.parseCommand(AddTaskCommand.COMMAND_WORD + " "
                             + PREFIX_NAME + "ALPHA_TASK "
                             + PREFIX_PROJECT + "1 "
-                            + PREFIX_DEADLINE + "2023-11-11 2359");
+                            + PREFIX_DEADLINE + "11-11-2023 2359");
         AddTaskCommand expected = new AddTaskCommand(ALPHA_TASK, ParserUtil.parseIndex("1"));
+        assertEquals(expected, command);
+    }
+
+    @Test
+    public void parseCommand_deleteTask() throws Exception {
+        DeleteTaskCommand command = (DeleteTaskCommand) parser.parseCommand(DeleteTaskCommand.COMMAND_WORD + " "
+                + PREFIX_PROJECT + "1 "
+                + PREFIX_TASK + "1 2 3");
+        Index projectIndex = Index.fromOneBased(1);
+        List<Index> taskIndexes = new ArrayList<>();
+        taskIndexes.add(Index.fromOneBased(1));
+        taskIndexes.add(Index.fromOneBased(2));
+        taskIndexes.add(Index.fromOneBased(3));
+        taskIndexes.sort((a, b) -> b.getZeroBased() - a.getZeroBased());
+        DeleteTaskCommand expected = new DeleteTaskCommand(projectIndex, taskIndexes);
         assertEquals(expected, command);
     }
 

--- a/src/test/java/seedu/address/model/task/TaskListTest.java
+++ b/src/test/java/seedu/address/model/task/TaskListTest.java
@@ -15,6 +15,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.commons.core.index.Index;
 import seedu.address.model.task.exceptions.TaskNotFoundException;
 
 public class TaskListTest {
@@ -36,7 +37,11 @@ public class TaskListTest {
 
     @Test
     public void remove_nullTask_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> taskList.remove(null));
+        assertThrows(NullPointerException.class, () -> taskList.remove((Task) null));
+    }
+    @Test
+    public void remove_nullTaskIndex_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> taskList.remove((Index) null));
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/ModelStubWithEmptyProjectList.java
+++ b/src/test/java/seedu/address/testutil/ModelStubWithEmptyProjectList.java
@@ -1,0 +1,45 @@
+package seedu.address.testutil;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.util.function.Predicate;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import seedu.address.model.employee.Employee;
+import seedu.address.model.project.Project;
+import seedu.address.model.task.Task;
+
+/**
+ * A model stub with an empty project list.
+ */
+public class ModelStubWithEmptyProjectList extends ModelStub {
+    @Override
+    public ObservableList<Project> getFilteredProjectList() {
+        ObservableList<Project> filteredList = FXCollections.observableArrayList();
+        return filteredList;
+    }
+    @Override
+    public boolean hasProject(Project project) {
+        requireNonNull(project);
+        return false;
+    }
+    @Override
+    public void updateFilteredProjectList(Predicate<Project> predicate) {
+        // do nothing - no need to update the model stub with just one project
+    }
+    @Override
+    public void setProject(Project project, Project editedProject) {
+        requireAllNonNull(project, editedProject);
+    }
+    @Override
+    public void addTask(Task task) {
+        // do nothing
+    }
+    @Override
+    public ObservableList<Employee> getFilteredEmployeeList() {
+        ObservableList<Employee> filteredList = FXCollections.observableArrayList();
+        return filteredList;
+    }
+}

--- a/src/test/java/seedu/address/testutil/TaskBuilder.java
+++ b/src/test/java/seedu/address/testutil/TaskBuilder.java
@@ -12,7 +12,7 @@ import seedu.address.model.task.Task;
  */
 public class TaskBuilder {
     public static final String DEFAULT_NAME = "ALPHA_TASK";
-    public static final String DEFAULT_DEADLINE = "2023-11-11 2359";
+    public static final String DEFAULT_DEADLINE = "11-11-2023 2359";
     public static final boolean DEFAULT_COMPLETION_STATUS = false;
 
     private String name;

--- a/src/test/java/seedu/address/testutil/TypicalProjects.java
+++ b/src/test/java/seedu/address/testutil/TypicalProjects.java
@@ -20,7 +20,7 @@ import seedu.address.model.project.ProjectPriority;
  * A utility class containing a list of {@code Project} objects to be used in tests.
  */
 public class TypicalProjects {
-    public static final Project ALPHA = new ProjectBuilder().build();
+    public static final Project ALPHA = new ProjectBuilder().withTasks(ALPHA_TASK).build();
     public static final Project BETA = new ProjectBuilder().withName("Beta").withEmployees(BENSON).withTasks(ALPHA_TASK)
             .withDeadline("10-12-2022").withCompletionStatus(false).build();
     public static final Project DELTA = new ProjectBuilder().withName("Delta").withEmployees(DANIEL, FIONA)

--- a/src/test/java/seedu/address/testutil/TypicalTasks.java
+++ b/src/test/java/seedu/address/testutil/TypicalTasks.java
@@ -13,7 +13,7 @@ import seedu.address.model.task.Task;
  * A utility class containing a list of {@code task} objects to be used in tests.
  */
 public class TypicalTasks {
-    public static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HHmm");
+    public static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("dd-MM-yyyy HHmm");
     public static final LocalDateTime DEFAULT_DEADLINE = LocalDateTime.parse("2023-11-11 2359", FORMATTER);
 
     public static final Task ALPHA_TASK = new TaskBuilder().build();

--- a/src/test/java/seedu/address/testutil/TypicalTasks.java
+++ b/src/test/java/seedu/address/testutil/TypicalTasks.java
@@ -14,7 +14,7 @@ import seedu.address.model.task.Task;
  */
 public class TypicalTasks {
     public static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("dd-MM-yyyy HHmm");
-    public static final LocalDateTime DEFAULT_DEADLINE = LocalDateTime.parse("2023-11-11 2359", FORMATTER);
+    public static final LocalDateTime DEFAULT_DEADLINE = LocalDateTime.parse("11-11-2023 2359", FORMATTER);
 
     public static final Task ALPHA_TASK = new TaskBuilder().build();
     public static final Task BETA_TASK = new TaskBuilder().withName("Beta")


### PR DESCRIPTION
### Commands implemented:

`deleteT`, to delete tasks from a certain project.

Multiple tasks can be deleted at once.

### Command format:
`deleteT pr/PROJECT_INDEX t/TASK_INDEXES e.g. deleteT pr/1 t/1 2 3`


### Example of usage:

#### Before execution of `deleteT`:
<img width="425" alt="image" src="https://github.com/AY2324S1-CS2103T-T08-3/tp/assets/64006665/969c4323-25c2-4512-884e-c574e07fc633">

#### After execution:
<img width="425" alt="image" src="https://github.com/AY2324S1-CS2103T-T08-3/tp/assets/64006665/52c6be49-4504-4be8-8791-d5148527c00c">



### Other notes:
- Minor implementation note: Indexes are sorted in descending order, so that deleting them in that order maintains the indexes of items that are before the current item to delete.

        taskIndexes.sort((a, b) -> b.getZeroBased() - a.getZeroBased());

- Also changed task deadline formats:
`addT n/TASK_NAME d/DEADLINE`~yyyy-MM-dd HHmm~ dd-mm-yyyy HHmm

- Ui update: project cards will not display the `tasks` section if the project contains no tasks. Project 1 does not have any tasks in the below screenshot, while project 2 has one task.
- 
<img width="415" alt="image" src="https://github.com/AY2324S1-CS2103T-T08-3/tp/assets/64006665/8915cf6b-c920-44a6-9dda-350053fb470d">


- Also ensured that no duplicate prefixes are allowed for projects, tasks in `markT`, `unmarkT`, `deleteT`