### PR TITLE
Make project name its own class / Change name prefix for addP

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -175,15 +175,15 @@ Format: `clear`
 
 Adds a new project in TaskHub
 
-Format: `addP pr/PROJECT_NAME [em/EMPLOYEE_INDEXES] ...`
+Format: `addP n/PROJECT_NAME [em/EMPLOYEE_INDEXES] ...`
 
 * Adds a new project with the employees assigned to the project.
 * Each employee index __must be separated with a space.__
 * The employee must exist in the employees list. 
 
 Examples: 
-* `addP pr/Project1 em/1` will add `Project1` to the projects list with the employee index 1 assigned to the project.
-* `addP pr/Project2` will add an empty `Project2` to the projects list.
+* `addP n/Project1 em/1` will add `Project1` to the projects list with the employee index 1 assigned to the project.
+* `addP n/Project2` will add an empty `Project2` to the projects list.
 
 ### Listing all projects: `listP`
 

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -64,7 +64,7 @@ public class Messages {
      */
     public static String format(Project project) {
         final StringBuilder builder = new StringBuilder();
-        builder.append("Name: " + project.name);
+        builder.append("Name: " + project.getName());
         builder.append("; Completed? " + (project.getCompletionStatus().isCompleted ? "Yes" : "No"));
         builder.append("; Deadline: " + (project.getDeadline().value.isEmpty() ? "Not set" : project.getDeadline()));
         builder.append("; Priority: " + project.getProjectPriority().value + "\n");

--- a/src/main/java/seedu/address/logic/commands/AddProjectCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddProjectCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PROJECT;
 
 import java.util.List;
@@ -21,9 +22,9 @@ public class AddProjectCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a project to the TaskHub. "
             + "Parameters: "
-            + PREFIX_PROJECT + "PROJECT_NAME\n"
+            + PREFIX_NAME + "PROJECT_NAME\n"
             + "Example: " + COMMAND_WORD + " "
-            + PREFIX_PROJECT + "Rebuild Taskxhub";
+            + PREFIX_NAME + "Rebuild Taskxhub";
 
 
     public static final String MESSAGE_SUCCESS = "New project added: %1$s";

--- a/src/main/java/seedu/address/logic/commands/AddProjectCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddProjectCommand.java
@@ -2,7 +2,6 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PROJECT;
 
 import java.util.List;
 

--- a/src/main/java/seedu/address/logic/commands/AddTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddTaskCommand.java
@@ -64,9 +64,7 @@ public class AddTaskCommand extends Command {
         // Add a task to the project with the selected index.
         projectToEdit.addTask(this.task);
 
-        Project editedProject = new Project(projectToEdit.getNameString(),
-                projectToEdit.getEmployees(), projectToEdit.getTasks(),
-                projectToEdit.getProjectPriority(), projectToEdit.getDeadline(), projectToEdit.getCompletionStatus());
+        Project editedProject = new Project(projectToEdit);
 
         // update model and filtered list for Ui update.
         model.setProject(projectToEdit, editedProject);

--- a/src/main/java/seedu/address/logic/commands/AssignProjectCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AssignProjectCommand.java
@@ -56,15 +56,14 @@ public class AssignProjectCommand extends Command {
         }
 
         Project projectToEdit = lastShownProjectList.get(projectIndex.getZeroBased());
-        Project editedProject = new Project(projectToEdit.name, projectToEdit.employeeList, projectToEdit.getTasks(),
-                projectToEdit.getProjectPriority(), projectToEdit.getDeadline(), projectToEdit.getCompletionStatus());
+        Project editedProject = new Project(projectToEdit);
         for (Index employeeIndex : employeeIndexes) {
             if (employeeIndex.getZeroBased() >= lastShownEmployeeList.size()) {
                 throw new CommandException(Messages.MESSAGE_INVALID_EMPLOYEE_DISPLAYED_INDEX);
             }
             Employee employeeToAdd = lastShownEmployeeList.get(employeeIndex.getZeroBased());
-            if (!editedProject.employeeList.contains(employeeToAdd)) {
-                editedProject.employeeList.add(employeeToAdd);
+            if (!editedProject.getEmployees().contains(employeeToAdd)) {
+                editedProject.getEmployees().add(employeeToAdd);
             }
         }
 

--- a/src/main/java/seedu/address/logic/commands/AssignTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AssignTaskCommand.java
@@ -80,7 +80,7 @@ public class AssignTaskCommand extends Command {
         TaskList editedTaskList = new TaskList();
         editedTaskList.setTasks(projectTaskListToEdit.asUnmodifiableObservableList());
         editedTaskList.setTask(taskIndex, editedTask);
-        Project editedProject = new Project(projectToEdit.getNameString(),
+        Project editedProject = new Project(projectToEdit.getName(),
                 projectToEdit.getEmployees(),
                 editedTaskList,
                 projectToEdit.getProjectPriority(),

--- a/src/main/java/seedu/address/logic/commands/DeleteEmployeeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteEmployeeCommand.java
@@ -50,7 +50,7 @@ public class DeleteEmployeeCommand extends Command {
             if (employeeList.contains(employeeToDelete)) {
                 employeeList.remove(employeeToDelete);
             }
-            model.setProject(project, new Project(project.getNameString(), employeeList, project.getTasks(),
+            model.setProject(project, new Project(project.getName(), employeeList, project.getTasks(),
                     project.getProjectPriority(), project.getDeadline(), project.getCompletionStatus()));
 
         });

--- a/src/main/java/seedu/address/logic/commands/DeleteTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteTaskCommand.java
@@ -78,11 +78,11 @@ public class DeleteTaskCommand extends Command {
         }
 
         // Create new project with updated tasks
-        Project updatedProject = new Project(targetProject.getNameString(), targetProject.getEmployees(),
+        Project updatedProject = new Project(targetProject.getName(), targetProject.getEmployees(),
                 lastShownTaskList, targetProject.getProjectPriority(),
                 targetProject.getDeadline(), targetProject.getCompletionStatus());
 
-        projectName = updatedProject.getNameString();
+        projectName = updatedProject.getName().toString();
 
         model.setProject(targetProject, updatedProject);
         model.updateFilteredProjectList(Model.PREDICATE_SHOW_ALL_PROJECTS);

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -93,7 +93,7 @@ public class EditCommand extends Command {
             if (employeeList.contains(employeeToEdit)) {
                 employeeList.setEmployee(employeeToEdit, editedEmployee);
             }
-            model.setProject(project, new Project(project.getNameString(), employeeList, project.getTasks(),
+            model.setProject(project, new Project(project.getName(), employeeList, project.getTasks(),
                     project.getProjectPriority(), project.getDeadline(), project.getCompletionStatus()));
         });
         model.updateFilteredProjectList(PREDICATE_SHOW_ALL_PROJECTS);

--- a/src/main/java/seedu/address/logic/commands/MarkProjectCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkProjectCommand.java
@@ -60,7 +60,7 @@ public class MarkProjectCommand extends Command {
             assert projectIndex.getZeroBased() < lastShownProjectList.size();
 
             Project projectToMark = lastShownProjectList.get(projectIndex.getZeroBased());
-            Project markedProject = new Project(projectToMark.name, projectToMark.employeeList,
+            Project markedProject = new Project(projectToMark.getName(), projectToMark.getEmployees(),
                     projectToMark.getTasks(),
                     projectToMark.getProjectPriority(), projectToMark.getDeadline(), new CompletionStatus(true));
             model.setProject(projectToMark, markedProject);

--- a/src/main/java/seedu/address/logic/commands/MarkTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkTaskCommand.java
@@ -78,11 +78,11 @@ public class MarkTaskCommand extends Command {
         }
 
         // Create new project with updated tasks
-        Project updatedProject = new Project(targetProject.getNameString(), targetProject.getEmployees(),
+        Project updatedProject = new Project(targetProject.getName(), targetProject.getEmployees(),
                 lastShownTaskList, targetProject.getProjectPriority(),
                 targetProject.getDeadline(), targetProject.getCompletionStatus());
 
-        projectName = updatedProject.getNameString();
+        projectName = updatedProject.getName().toString();
 
         model.setProject(targetProject, updatedProject);
         model.updateFilteredProjectList(Model.PREDICATE_SHOW_ALL_PROJECTS);

--- a/src/main/java/seedu/address/logic/commands/PriorityProjectCommand.java
+++ b/src/main/java/seedu/address/logic/commands/PriorityProjectCommand.java
@@ -62,7 +62,7 @@ public class PriorityProjectCommand extends Command {
 
     private static Project createProjectWithNewPriority(Project projectToSetPriority, ProjectPriority priority) {
         assert projectToSetPriority != null;
-        return new Project(projectToSetPriority.getNameString(),
+        return new Project(projectToSetPriority.getName(),
                 projectToSetPriority.getEmployees(),
                 projectToSetPriority.getTasks(), priority,
                 projectToSetPriority.getDeadline(),

--- a/src/main/java/seedu/address/logic/commands/ProjectDeadlineCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ProjectDeadlineCommand.java
@@ -54,7 +54,7 @@ public class ProjectDeadlineCommand extends Command {
         }
 
         Project projectToEdit = lastShownList.get(index.getZeroBased());
-        Project editedProject = new Project(projectToEdit.getNameString(), projectToEdit.getEmployees(),
+        Project editedProject = new Project(projectToEdit.getName(), projectToEdit.getEmployees(),
                 projectToEdit.getTasks(),
                 projectToEdit.getProjectPriority(), deadline, projectToEdit.getCompletionStatus());
 

--- a/src/main/java/seedu/address/logic/commands/UnassignProjectCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnassignProjectCommand.java
@@ -62,8 +62,9 @@ public class UnassignProjectCommand extends Command {
         }
 
         Project projectToEdit = lastShownProjectList.get(projectIndex.getZeroBased());
-        Project editedProject = new Project(projectToEdit.name, projectToEdit.employeeList, projectToEdit.getTasks(),
-                projectToEdit.getProjectPriority(), projectToEdit.getDeadline(), projectToEdit.getCompletionStatus());
+        Project editedProject = new Project(projectToEdit.getName(), projectToEdit.getEmployees(),
+                projectToEdit.getTasks(), projectToEdit.getProjectPriority(), projectToEdit.getDeadline(),
+                projectToEdit.getCompletionStatus());
 
         // Check if all specified employees are in the project
         for (Index employeeIndex : employeeIndexes) {
@@ -72,10 +73,10 @@ public class UnassignProjectCommand extends Command {
             }
 
             Employee employeeToRemove = lastShownEmployeeList.get(employeeIndex.getZeroBased());
-            if (!editedProject.employeeList.contains(employeeToRemove)) {
+            if (!editedProject.getEmployees().contains(employeeToRemove)) {
                 throw new CommandException(String.format(MESSAGE_UNASSIGN_PROJECT_FAILURE,
                         employeeToRemove.getName(), employeeIndex.getOneBased(),
-                        projectToEdit.name, projectIndex.getOneBased()));
+                        projectToEdit.getName(), projectIndex.getOneBased()));
             }
         }
 

--- a/src/main/java/seedu/address/logic/commands/UnassignTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnassignTaskCommand.java
@@ -73,7 +73,7 @@ public class UnassignTaskCommand extends Command {
         TaskList editedTaskList = new TaskList();
         editedTaskList.setTasks(projectTaskListToEdit.asUnmodifiableObservableList());
         editedTaskList.setTask(taskIndex, editedTask);
-        Project editedProject = new Project(projectToEdit.getNameString(),
+        Project editedProject = new Project(projectToEdit.getName(),
                 projectToEdit.getEmployees(),
                 editedTaskList,
                 projectToEdit.getProjectPriority(),

--- a/src/main/java/seedu/address/logic/commands/UnmarkProjectCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnmarkProjectCommand.java
@@ -60,9 +60,8 @@ public class UnmarkProjectCommand extends Command {
             assert projectIndex.getZeroBased() < lastShownProjectList.size();
 
             Project projectToUnmark = lastShownProjectList.get(projectIndex.getZeroBased());
-            Project unmarkedProject = new Project(projectToUnmark.name, projectToUnmark.employeeList,
-                    projectToUnmark.getTasks(),
-                    projectToUnmark.getProjectPriority(), projectToUnmark.getDeadline(),
+            Project unmarkedProject = new Project(projectToUnmark.getName(), projectToUnmark.getEmployees(),
+                    projectToUnmark.getTasks(), projectToUnmark.getProjectPriority(), projectToUnmark.getDeadline(),
                     new CompletionStatus(false));
             model.setProject(projectToUnmark, unmarkedProject);
         }

--- a/src/main/java/seedu/address/logic/commands/UnmarkTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnmarkTaskCommand.java
@@ -77,11 +77,11 @@ public class UnmarkTaskCommand extends Command {
         }
 
         // Create new project with updated tasks
-        Project updatedProject = new Project(targetProject.getNameString(), targetProject.getEmployees(),
+        Project updatedProject = new Project(targetProject.getName(), targetProject.getEmployees(),
                 lastShownTaskList, targetProject.getProjectPriority(),
                 targetProject.getDeadline(), targetProject.getCompletionStatus());
 
-        projectName = updatedProject.getNameString();
+        projectName = updatedProject.getName().toString();
 
         model.setProject(targetProject, updatedProject);
         model.updateFilteredProjectList(Model.PREDICATE_SHOW_ALL_PROJECTS);

--- a/src/main/java/seedu/address/logic/parser/AddProjectCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddProjectCommandParser.java
@@ -2,7 +2,7 @@ package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMPLOYEE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PROJECT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -27,15 +27,15 @@ public class AddProjectCommandParser implements Parser<AddProjectCommand> {
      */
     public AddProjectCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_PROJECT, PREFIX_EMPLOYEE);
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_EMPLOYEE);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_PROJECT)
+        if (!arePrefixesPresent(argMultimap, PREFIX_NAME)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddProjectCommand.MESSAGE_USAGE));
         }
 
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_PROJECT);
-        Project project = ParserUtil.parseProject(argMultimap.getValue(PREFIX_PROJECT).get());
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME);
+        Project project = ParserUtil.parseProject(argMultimap.getValue(PREFIX_NAME).get());
         List<Index> employeeIndexes = new ArrayList<>();
 
         if (argMultimap.getValue(PREFIX_EMPLOYEE).isPresent()) {

--- a/src/main/java/seedu/address/logic/parser/AddProjectCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddProjectCommandParser.java
@@ -41,7 +41,7 @@ public class AddProjectCommandParser implements Parser<AddProjectCommand> {
         if (argMultimap.getValue(PREFIX_EMPLOYEE).isPresent()) {
             employeeIndexes = ParserUtil.parseIndexes(argMultimap.getValue(PREFIX_EMPLOYEE).get());
         }
-        project = new Project(project.getNameString());
+        project = new Project(project.getName());
 
         return new AddProjectCommand(project, employeeIndexes);
     }

--- a/src/main/java/seedu/address/model/project/Name.java
+++ b/src/main/java/seedu/address/model/project/Name.java
@@ -1,0 +1,67 @@
+package seedu.address.model.project;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
+/**
+ * Represents a Project's name in the TaskHub.
+ * Guarantees: immutable; is valid as declared in {@link #isValidName(String)}
+ */
+public class Name {
+
+    public static final String MESSAGE_CONSTRAINTS =
+            "Names should only contain alphanumeric characters and spaces, and it should not be blank";
+
+    /*
+     * The first character of the address must not be a whitespace,
+     * otherwise " " (a blank string) becomes a valid input.
+     */
+    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+
+    public final String fullName;
+
+    /**
+     * Constructs a {@code Name}.
+     *
+     * @param name A valid name.
+     */
+    public Name(String name) {
+        requireNonNull(name);
+        checkArgument(isValidName(name), MESSAGE_CONSTRAINTS);
+        fullName = name;
+    }
+
+    /**
+     * Returns true if a given string is a valid name.
+     */
+    public static boolean isValidName(String test) {
+        return test.matches(VALIDATION_REGEX);
+    }
+
+
+    @Override
+    public String toString() {
+        return fullName;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof Name)) {
+            return false;
+        }
+
+        Name otherName = (Name) other;
+        return fullName.equals(otherName.fullName);
+    }
+
+    @Override
+    public int hashCode() {
+        return fullName.hashCode();
+    }
+
+}

--- a/src/main/java/seedu/address/model/project/Project.java
+++ b/src/main/java/seedu/address/model/project/Project.java
@@ -23,8 +23,8 @@ public class Project {
      */
     public static final String VALIDATION_REGEX = "[^\\s].*";
 
-    public final String name;
-    public final UniqueEmployeeList employeeList;
+    private final Name name;
+    private final UniqueEmployeeList employeeList;
     private final TaskList tasks;
     private final Deadline deadline;
     private final ProjectPriority projectPriority;
@@ -34,11 +34,11 @@ public class Project {
     /**
      * Constructs a {@code Project}.
      *
-     * @param project A valid Project.
+     * @param name A valid name.
      */
-    public Project(String project) {
-        requireNonNull(project);
-        this.name = project;
+    public Project(String name) {
+        requireNonNull(name);
+        this.name = new Name(name);
         this.projectPriority = new ProjectPriority("normal");
         this.deadline = new Deadline("");
         this.employeeList = new UniqueEmployeeList();
@@ -49,21 +49,51 @@ public class Project {
     /**
      * Constructs a {@code Project}.
      *
-     * @param project A valid Project.
+     * @param name A valid name.
+     */
+    public Project(Name name) {
+        requireNonNull(name);
+        this.name = name;
+        this.projectPriority = new ProjectPriority("normal");
+        this.deadline = new Deadline("");
+        this.employeeList = new UniqueEmployeeList();
+        this.completionStatus = new CompletionStatus(false);
+        this.tasks = new TaskList();
+    }
+
+    /**
+     * Constructs a {@code Project}.
+     *
+     * @param project A valid project.
+     */
+    public Project(Project project) {
+        requireNonNull(project);
+        this.name = project.getName();
+        this.projectPriority = project.getProjectPriority();
+        this.deadline = project.getDeadline();
+        this.employeeList = project.getEmployees();
+        this.completionStatus = project.getCompletionStatus();
+        this.tasks = project.getTasks();
+    }
+
+    /**
+     * Constructs a {@code Project}.
+     *
+     * @param name A valid name.
      * @param employees A list of Employees that are in the project
      * @param tasks A list of Tasks that are in the project
      * @param priority A valid ProjectPriority for the project.
      * @param deadline A valid Deadline for the project.
      * @param completionStatus A valid CompletionStatus for the project.
      */
-    public Project(String project,
+    public Project(Name name,
                    UniqueEmployeeList employees,
                    TaskList tasks,
                    ProjectPriority priority,
                    Deadline deadline,
                    CompletionStatus completionStatus) {
-        requireNonNull(project);
-        this.name = project;
+        requireNonNull(name);
+        this.name = name;
         this.projectPriority = priority;
         this.employeeList = employees;
         this.tasks = tasks;
@@ -71,8 +101,8 @@ public class Project {
         this.completionStatus = completionStatus;
     }
 
-    public String getNameString() {
-        return this.name;
+    public Name getName() {
+        return name;
     }
 
     public UniqueEmployeeList getEmployees() {
@@ -158,7 +188,7 @@ public class Project {
 
     @Override
     public String toString() {
-        return name;
+        return name.toString();
     }
 
     @Override

--- a/src/main/java/seedu/address/model/project/ProjectNameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/project/ProjectNameContainsKeywordsPredicate.java
@@ -20,7 +20,7 @@ public class ProjectNameContainsKeywordsPredicate implements Predicate<Project> 
     @Override
     public boolean test(Project project) {
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(project.getNameString(), keyword));
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(project.getName().toString(), keyword));
     }
 
     @Override

--- a/src/main/java/seedu/address/storage/JsonAdaptedProject.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedProject.java
@@ -8,11 +8,11 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.address.commons.exceptions.IllegalValueException;
-import seedu.address.model.employee.Name;
 import seedu.address.model.employee.UniqueEmployeeList;
 import seedu.address.model.employee.exceptions.DuplicateEmployeeException;
 import seedu.address.model.project.CompletionStatus;
 import seedu.address.model.project.Deadline;
+import seedu.address.model.project.Name;
 import seedu.address.model.project.Project;
 import seedu.address.model.project.ProjectPriority;
 import seedu.address.model.task.TaskList;
@@ -57,7 +57,7 @@ public class JsonAdaptedProject {
      * Converts a given {@code project} into this class for Jackson use.
      */
     public JsonAdaptedProject(Project source) {
-        name = source.name;
+        name = source.getName().toString();
         employees.addAll(source.getEmployees().asUnmodifiableObservableList().stream()
                 .map(JsonAdaptedEmployee::new)
                 .collect(Collectors.toList()));
@@ -102,6 +102,7 @@ public class JsonAdaptedProject {
         if (!Project.isValidProject(name)) {
             throw new IllegalValueException(Project.MESSAGE_CONSTRAINTS);
         }
+        final Name modelName = new Name(name);
 
         if (priority == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
@@ -127,6 +128,6 @@ public class JsonAdaptedProject {
         }
         final CompletionStatus modelCompletionStatus = new CompletionStatus(this.completionStatus);
 
-        return new Project(name, employeeList, taskList, modelPriority, modelDeadline, modelCompletionStatus);
+        return new Project(modelName, employeeList, taskList, modelPriority, modelDeadline, modelCompletionStatus);
     }
 }

--- a/src/main/java/seedu/address/ui/ProjectCard.java
+++ b/src/main/java/seedu/address/ui/ProjectCard.java
@@ -61,7 +61,7 @@ public class ProjectCard extends UiPart<Region> {
         id.setText(displayedIndex + ". ");
 
         // Set the name
-        name.setText(project.getNameString());
+        name.setText(project.getName().toString());
 
         // Set the list of employees
         String listOfEmployeesString =

--- a/src/test/java/seedu/address/logic/commands/AssignTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AssignTaskCommandTest.java
@@ -70,7 +70,7 @@ public class AssignTaskCommandTest {
         editedTaskList.setTasks(projectToAssignTasks.getTasks().asUnmodifiableObservableList());
         editedTaskList.setTask(INDEX_FIRST_TASK, taskAfterAssigning);
 
-        Project projectWithAssignedTask = new Project(projectToAssignTasks.name,
+        Project projectWithAssignedTask = new Project(projectToAssignTasks.getName(),
                 projectToAssignTasks.getEmployees(),
                 editedTaskList,
                 projectToAssignTasks.getProjectPriority(),

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -68,8 +68,8 @@ public class CommandTestUtil {
     public static final String ADDRESS_DESC_BOB = " " + PREFIX_ADDRESS + VALID_ADDRESS_BOB;
     public static final String TAG_DESC_FRIEND = " " + PREFIX_TAG + VALID_TAG_FRIEND;
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
-    public static final String PROJECT_DESC_AMY = " " + PREFIX_PROJECT + VALID_PROJECT_AMY;
-    public static final String PROJECT_DESC_BOB = " " + PREFIX_PROJECT + VALID_PROJECT_BOB;
+    public static final String PROJECT_DESC_AMY = " " + PREFIX_NAME + VALID_PROJECT_AMY;
+    public static final String PROJECT_DESC_BOB = " " + PREFIX_NAME + VALID_PROJECT_BOB;
     public static final String PROJECT_PRIORITY_AMY = " " + PREFIX_PRIORITY + VALID_PRIORITY_AMY;
 
     // Project field descriptions

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -168,7 +168,7 @@ public class CommandTestUtil {
         assertTrue(targetIndex.getZeroBased() < model.getFilteredProjectList().size());
 
         Project project = model.getFilteredProjectList().get(targetIndex.getZeroBased());
-        final String[] splitName = project.getNameString().split("\\s+");
+        final String[] splitName = project.getName().toString().split("\\s+");
         model.updateFilteredProjectList(new ProjectNameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
 
         assertEquals(1, model.getFilteredProjectList().size());

--- a/src/test/java/seedu/address/logic/commands/DeleteTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteTaskCommandTest.java
@@ -38,7 +38,7 @@ public class DeleteTaskCommandTest {
         taskIndexes.add(taskIndex);
         CommandResult commandResult = new DeleteTaskCommand(projectIndex, taskIndexes).execute(modelStub);
         assertEquals(String.format(DeleteTaskCommand.MESSAGE_TASKS_DELETED_SUCCESSFULLY,
-                                   taskIndexes.size(), ALPHA.getNameString()),
+                                   taskIndexes.size(), ALPHA.getName()),
                     commandResult.getFeedbackToUser());
     }
     @Test

--- a/src/test/java/seedu/address/logic/commands/MarkTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/MarkTaskCommandTest.java
@@ -45,7 +45,7 @@ public class MarkTaskCommandTest {
 
         CommandResult commandResult = new MarkTaskCommand(projectIndex, taskIndexes).execute(modelStub);
         assertEquals(String.format(MESSAGE_TASKS_MARKED_SUCCESSFULLY, taskIndexes.size(),
-                        targetProject.getNameString()), commandResult.getFeedbackToUser());
+                        targetProject.getName()), commandResult.getFeedbackToUser());
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/PriorityProjectCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/PriorityProjectCommandTest.java
@@ -38,7 +38,7 @@ public class PriorityProjectCommandTest {
         Project projectToSetPriority = model.getFilteredProjectList().get(INDEX_FIRST_PROJECT.getZeroBased());
         PriorityProjectCommand projectPriorityCommand = new PriorityProjectCommand(new ProjectPriority("high"),
                 INDEX_FIRST_PROJECT);
-        Project projectWithNewPriority = new Project(projectToSetPriority.name,
+        Project projectWithNewPriority = new Project(projectToSetPriority.getName(),
                 projectToSetPriority.getEmployees(),
                 projectToSetPriority.getTasks(),
                 new ProjectPriority("high"),

--- a/src/test/java/seedu/address/logic/commands/UnassignProjectCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UnassignProjectCommandTest.java
@@ -69,7 +69,7 @@ public class UnassignProjectCommandTest {
 
         // Verify that the employees have been removed from the project in the model
         Project projectInModel = expectedModel.getFilteredProjectList().get(INDEX_FIRST_PROJECT.getZeroBased());
-        assertTrue(projectInModel.employeeList.isEmpty());
+        assertTrue(projectInModel.getEmployees().isEmpty());
     }
 
     @Test
@@ -99,14 +99,14 @@ public class UnassignProjectCommandTest {
 
         String expectedFailureMessage = String.format(UnassignProjectCommand.MESSAGE_UNASSIGN_PROJECT_FAILURE,
                 ALICE.getName(), INDEX_FIRST_EMPLOYEE.getOneBased(),
-                projectToUnassign.getNameString(), INDEX_FIRST_PROJECT.getOneBased());
+                projectToUnassign.getName(), INDEX_FIRST_PROJECT.getOneBased());
 
         // Alice is already unassigned from project, so command should fail
         assertCommandFailure(unassignProjectCommand, model, expectedFailureMessage);
 
         // Verify that Alice has been removed and Benson is still in the project
         Project projectInModel = expectedModel.getFilteredProjectList().get(INDEX_FIRST_PROJECT.getZeroBased());
-        assertTrue(projectInModel.employeeList.contains(BENSON));
+        assertTrue(projectInModel.getEmployees().contains(BENSON));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/UnassignTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UnassignTaskCommandTest.java
@@ -57,7 +57,7 @@ public class UnassignTaskCommandTest {
         editedTaskList.setTasks(projectToEdit.getTasks().asUnmodifiableObservableList());
         editedTaskList.setTask(INDEX_ASSIGNED_TASK, taskAfterUnassigning);
 
-        Project projectWithAssignedTask = new Project(projectToEdit.name,
+        Project projectWithAssignedTask = new Project(projectToEdit.getName(),
                 projectToEdit.getEmployees(),
                 editedTaskList,
                 projectToEdit.getProjectPriority(),

--- a/src/test/java/seedu/address/logic/commands/UnmarkTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UnmarkTaskCommandTest.java
@@ -45,7 +45,7 @@ public class UnmarkTaskCommandTest {
 
         CommandResult commandResult = new UnmarkTaskCommand(projectIndex, taskIndexes).execute(modelStub);
         assertEquals(String.format(MESSAGE_TASKS_UNMARKED_SUCCESSFULLY, taskIndexes.size(),
-                        targetProject.getNameString()), commandResult.getFeedbackToUser());
+                        targetProject.getName()), commandResult.getFeedbackToUser());
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/TaskHubParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/TaskHubParserTest.java
@@ -197,7 +197,7 @@ public class TaskHubParserTest {
     @Test
     public void parseCommand_addProject() throws Exception {
         AddProjectCommand command = (AddProjectCommand) parser.parseCommand(AddProjectCommand.COMMAND_WORD + " "
-                            + PREFIX_PROJECT + "Alpha");
+                            + PREFIX_NAME + "Alpha");
         AddProjectCommand expected = new AddProjectCommand(new Project("Alpha"), new ArrayList<>());
         assertEquals(expected, command);
     }

--- a/src/test/java/seedu/address/model/project/ProjectTest.java
+++ b/src/test/java/seedu/address/model/project/ProjectTest.java
@@ -16,7 +16,7 @@ public class ProjectTest {
 
     @Test
     public void constructor_null_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> new Project(null));
+        assertThrows(NullPointerException.class, () -> new Project((String) null));
     }
 
     @Test
@@ -41,7 +41,7 @@ public class ProjectTest {
         assertTrue(project.equals(project));
 
         // same values -> returns true
-        Project projectCopy = new Project(project.name);
+        Project projectCopy = new Project(project.getName());
         assertTrue(project.equals(projectCopy));
 
         // different types -> returns false
@@ -60,7 +60,7 @@ public class ProjectTest {
         Project project = new Project("some project");
         project.addEmployee(ALICE);
         project.addEmployee(BOB);
-        assertTrue(project.employeeList.contains(ALICE) && project.employeeList.contains(BOB));
+        assertTrue(project.getEmployees().contains(ALICE) && project.getEmployees().contains(BOB));
     }
 
     @Test
@@ -68,9 +68,9 @@ public class ProjectTest {
         Project project = new Project("some project");
         project.addEmployee(ALICE);
         project.addEmployee(BOB);
-        assertTrue(project.employeeList.contains(ALICE) && project.employeeList.contains(BOB));
+        assertTrue(project.getEmployees().contains(ALICE) && project.getEmployees().contains(BOB));
         project.removeEmployee(ALICE);
-        assertTrue(!project.employeeList.contains(ALICE) && project.employeeList.contains(BOB));
+        assertTrue(!project.getEmployees().contains(ALICE) && project.getEmployees().contains(BOB));
     }
 
     @Test

--- a/src/test/java/seedu/address/storage/JsonAdaptedProjectTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedProjectTest.java
@@ -21,7 +21,7 @@ public class JsonAdaptedProjectTest {
     public static final String INVALID_DEADLINE = "32/13/2024";
     public static final String INVALID_PRIORITY = "    ";
 
-    public static final String VALID_NAME = ALPHA.name;
+    public static final String VALID_NAME = ALPHA.getName().toString();
     public static final List<JsonAdaptedEmployee> VALID_EMPLOYEES = ALPHA.getEmployees().asUnmodifiableObservableList()
             .stream()
             .map(JsonAdaptedEmployee::new)

--- a/src/test/java/seedu/address/testutil/ProjectBuilder.java
+++ b/src/test/java/seedu/address/testutil/ProjectBuilder.java
@@ -7,6 +7,7 @@ import seedu.address.model.employee.Employee;
 import seedu.address.model.employee.UniqueEmployeeList;
 import seedu.address.model.project.CompletionStatus;
 import seedu.address.model.project.Deadline;
+import seedu.address.model.project.Name;
 import seedu.address.model.project.Project;
 import seedu.address.model.project.ProjectPriority;
 import seedu.address.model.task.Task;
@@ -22,7 +23,7 @@ public class ProjectBuilder {
     public static final String DEFAULT_DEADLINE = "";
     public static final boolean DEFAULT_COMPLETION_STATUS = false;
 
-    private String projectName;
+    private Name projectName;
     private UniqueEmployeeList employeeList;
     private TaskList taskList;
     private Deadline deadline;
@@ -33,7 +34,7 @@ public class ProjectBuilder {
      * Instantiates a {@code Project} with the default details
      */
     public ProjectBuilder() {
-        projectName = DEFAULT_NAME;
+        projectName = new Name(DEFAULT_NAME);
         employeeList = new UniqueEmployeeList();
         employeeList.add(ALICE);
         taskList = new TaskList();
@@ -47,7 +48,7 @@ public class ProjectBuilder {
      * Initializes the ProjectBuilder with details of {@code toCopy}
      */
     public ProjectBuilder(Project toCopy) {
-        projectName = toCopy.name;
+        projectName = toCopy.getName();
         employeeList = toCopy.getEmployees();
         taskList = toCopy.getTasks();
         projectPriority = toCopy.getProjectPriority();
@@ -59,7 +60,7 @@ public class ProjectBuilder {
      * Sets the name of the {@code Project} we are building.
      */
     public ProjectBuilder withName(String name) {
-        this.projectName = name;
+        this.projectName = new Name(name);
         return this;
     }
 


### PR DESCRIPTION
Closes #164 

1. Created a new class for `name` in `Project` model, following OOP-style.
2. Made `employeeList` and `name` members private in `Project` class, following information-hiding principle.
3. Changed prefix for project name in `addP` command from: `addP pr/NAME ...` to `addP n/NAME ...`.