### PR TITLE
Implement editp command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditEmployeeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditEmployeeCommand.java
@@ -59,6 +59,7 @@ public class EditEmployeeCommand extends Command {
     private final EditEmployeeDescriptor editEmployeeDescriptor;
 
     /**
+     * Creates an EditEmployeeCommand to edit the specified {@code Employee}
      * @param index of the employee in the filtered employee list to edit
      * @param editEmployeeDescriptor details to edit the employee with
      */

--- a/src/main/java/seedu/address/logic/commands/EditEmployeeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditEmployeeCommand.java
@@ -34,9 +34,9 @@ import seedu.address.model.tag.Tag;
 /**
  * Edits the details of an existing employee in the TaskHub.
  */
-public class EditCommand extends Command {
+public class EditEmployeeCommand extends Command {
 
-    public static final String COMMAND_WORD = "edit";
+    public static final String COMMAND_WORD = "editE";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the employee identified "
             + "by the index number used in the displayed employee list. "
@@ -62,7 +62,7 @@ public class EditCommand extends Command {
      * @param index of the employee in the filtered employee list to edit
      * @param editEmployeeDescriptor details to edit the employee with
      */
-    public EditCommand(Index index, EditEmployeeDescriptor editEmployeeDescriptor) {
+    public EditEmployeeCommand(Index index, EditEmployeeDescriptor editEmployeeDescriptor) {
         requireNonNull(index);
         requireNonNull(editEmployeeDescriptor);
 
@@ -124,13 +124,13 @@ public class EditCommand extends Command {
         }
 
         // instanceof handles nulls
-        if (!(other instanceof EditCommand)) {
+        if (!(other instanceof EditEmployeeCommand)) {
             return false;
         }
 
-        EditCommand otherEditCommand = (EditCommand) other;
-        return index.equals(otherEditCommand.index)
-                && editEmployeeDescriptor.equals(otherEditCommand.editEmployeeDescriptor);
+        EditEmployeeCommand otherEditEmployeeCommand = (EditEmployeeCommand) other;
+        return index.equals(otherEditEmployeeCommand.index)
+                && editEmployeeDescriptor.equals(otherEditEmployeeCommand.editEmployeeDescriptor);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/EditProjectCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditProjectCommand.java
@@ -1,0 +1,174 @@
+package seedu.address.logic.commands;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.CollectionUtil;
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.project.CompletionStatus;
+import seedu.address.model.project.Deadline;
+import seedu.address.model.project.Name;
+import seedu.address.model.project.Project;
+import seedu.address.model.project.ProjectPriority;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DEADLINE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PRIORITY;
+
+public class EditProjectCommand extends Command {
+
+    public static final String COMMAND_WORD = "editP";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the project identified "
+            + "by the index number used in the displayed project list. "
+            + "Existing values will be overwritten by the input values.\n"
+            + "Parameters: INDEX (must be a positive integer) "
+            + "[" + PREFIX_NAME + "NAME] "
+            + "[" + PREFIX_PRIORITY + "PRIORITY] "
+            + "[" + PREFIX_DEADLINE + "DEADLINE] "
+            + "Example: " + COMMAND_WORD + " 1 "
+            + PREFIX_PRIORITY + "HIGH "
+            + PREFIX_DEADLINE + "2020-12-31";
+
+    public static final String MESSAGE_EDIT_PROJECT_SUCCESS = "Edited Project: %1$s";
+    public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
+    public static final String MESSAGE_DUPLICATE_PROJECT = "This project already exists in the TaskHub.";
+
+    public final Index index;
+    public final EditProjectDescriptor editProjectDescriptor;
+
+    public EditProjectCommand(Index index, EditProjectDescriptor editProjectDescriptor) {
+        requireNonNull(index);
+        requireNonNull(editProjectDescriptor);
+
+        this.index = index;
+        this.editProjectDescriptor = editProjectDescriptor;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Project> lastShownList = model.getFilteredProjectList();
+
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PROJECT_DISPLAYED_INDEX);
+        }
+
+        Project projectToEdit = lastShownList.get(index.getZeroBased());
+        Project editedProject = createEditedProject(projectToEdit, editProjectDescriptor);
+
+        if (!projectToEdit.isSameProject(editedProject) && model.hasProject(editedProject)) {
+            throw new CommandException(MESSAGE_DUPLICATE_PROJECT);
+        }
+
+        model.setProject(projectToEdit, editedProject);
+        model.updateFilteredProjectList(Model.PREDICATE_SHOW_ALL_PROJECTS);
+        return new CommandResult(String.format(MESSAGE_EDIT_PROJECT_SUCCESS, Messages.format(editedProject)));
+    }
+
+    private static Project createEditedProject(Project projectToEdit, EditProjectDescriptor editProjectDescriptor) {
+        assert projectToEdit != null;
+
+        Name updatedName = editProjectDescriptor.getName().orElse(projectToEdit.getName());
+        ProjectPriority updatedPriority = editProjectDescriptor.getPriority().orElse(projectToEdit.getProjectPriority());
+        Deadline updatedDeadline = editProjectDescriptor.getDeadline().orElse(projectToEdit.getDeadline());
+
+        return new Project(updatedName, projectToEdit.getEmployees(), projectToEdit.getTasks(), updatedPriority,
+                updatedDeadline, projectToEdit.getCompletionStatus());
+    }
+
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof EditProjectCommand)) {
+            return false;
+        }
+
+        EditProjectCommand otherEditProjectCommand = (EditProjectCommand) other;
+        return index.equals(otherEditProjectCommand.index)
+                && editProjectDescriptor.equals(otherEditProjectCommand.editProjectDescriptor);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("index", index)
+                .add("editProjectDescriptor", editProjectDescriptor)
+                .toString();
+    }
+
+    public static class EditProjectDescriptor {
+        private Name name;
+        private ProjectPriority priority;
+        private Deadline deadline;
+
+        public EditProjectDescriptor() {}
+
+        public EditProjectDescriptor(EditProjectDescriptor toCopy) {
+            setName(toCopy.name);
+            setPriority(toCopy.priority);
+            setDeadline(toCopy.deadline);
+        }
+
+        public boolean isAnyFieldEdited() {
+            return CollectionUtil.isAnyNonNull(name, priority, deadline);
+        }
+
+        public void setName(Name name) {
+            this.name = name;
+        }
+
+        public Optional<Name> getName() {
+            return Optional.ofNullable(name);
+        }
+
+        public void setPriority(ProjectPriority priority) {
+            this.priority = priority;
+        }
+
+        public Optional<ProjectPriority> getPriority() {
+            return Optional.ofNullable(priority);
+        }
+
+        public void setDeadline(Deadline deadline) {
+            this.deadline = deadline;
+        }
+
+        public Optional<Deadline> getDeadline() {
+            return Optional.ofNullable(deadline);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (other == this) {
+                return true;
+            }
+
+            if (!(other instanceof EditProjectDescriptor)) {
+                return false;
+            }
+
+            EditProjectDescriptor otherEditProjectDescriptor = (EditProjectDescriptor) other;
+            return Objects.equals(name, otherEditProjectDescriptor.name)
+                    && Objects.equals(priority, otherEditProjectDescriptor.priority)
+                    && Objects.equals(deadline, otherEditProjectDescriptor.deadline);
+        }
+
+        @Override
+        public String toString() {
+            return new ToStringBuilder(this)
+                    .add("name", name)
+                    .add("priority", priority)
+                    .add("deadline", deadline)
+                    .toString();
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/EditProjectCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditProjectCommand.java
@@ -1,26 +1,28 @@
 package seedu.address.logic.commands;
 
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DEADLINE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PRIORITY;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.CollectionUtil;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.project.CompletionStatus;
 import seedu.address.model.project.Deadline;
 import seedu.address.model.project.Name;
 import seedu.address.model.project.Project;
 import seedu.address.model.project.ProjectPriority;
 
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-
-import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_DEADLINE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PRIORITY;
-
+/**
+ * Edits the details of an existing project in the TaskHub.
+ */
 public class EditProjectCommand extends Command {
 
     public static final String COMMAND_WORD = "editP";
@@ -43,6 +45,10 @@ public class EditProjectCommand extends Command {
     public final Index index;
     public final EditProjectDescriptor editProjectDescriptor;
 
+    /**
+     * @param index of the project in the filtered project list to edit
+     * @param editProjectDescriptor details to edit the project with
+     */
     public EditProjectCommand(Index index, EditProjectDescriptor editProjectDescriptor) {
         requireNonNull(index);
         requireNonNull(editProjectDescriptor);
@@ -76,13 +82,15 @@ public class EditProjectCommand extends Command {
         assert projectToEdit != null;
 
         Name updatedName = editProjectDescriptor.getName().orElse(projectToEdit.getName());
-        ProjectPriority updatedPriority = editProjectDescriptor.getPriority().orElse(projectToEdit.getProjectPriority());
+        ProjectPriority updatedPriority = editProjectDescriptor.getPriority()
+                .orElse(projectToEdit.getProjectPriority());
         Deadline updatedDeadline = editProjectDescriptor.getDeadline().orElse(projectToEdit.getDeadline());
 
         return new Project(updatedName, projectToEdit.getEmployees(), projectToEdit.getTasks(), updatedPriority,
                 updatedDeadline, projectToEdit.getCompletionStatus());
     }
 
+    @Override
     public boolean equals(Object other) {
         if (other == this) {
             return true;
@@ -105,6 +113,10 @@ public class EditProjectCommand extends Command {
                 .toString();
     }
 
+    /**
+     * Stores the details to edit the project with. Each non-empty field value will replace the
+     * corresponding field value of the project.
+     */
     public static class EditProjectDescriptor {
         private Name name;
         private ProjectPriority priority;
@@ -112,12 +124,19 @@ public class EditProjectCommand extends Command {
 
         public EditProjectDescriptor() {}
 
+        /**
+         * Copy constructor.
+         * A defensive copy of {@code tags} is used internally.
+         */
         public EditProjectDescriptor(EditProjectDescriptor toCopy) {
             setName(toCopy.name);
             setPriority(toCopy.priority);
             setDeadline(toCopy.deadline);
         }
 
+        /**
+         * Returns true if at least one field is edited.
+         */
         public boolean isAnyFieldEdited() {
             return CollectionUtil.isAnyNonNull(name, priority, deadline);
         }

--- a/src/main/java/seedu/address/logic/commands/EditProjectCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditProjectCommand.java
@@ -46,6 +46,7 @@ public class EditProjectCommand extends Command {
     public final EditProjectDescriptor editProjectDescriptor;
 
     /**
+     * Creates an EditProjectCommand to edit the specified {@code Project}
      * @param index of the project in the filtered project list to edit
      * @param editProjectDescriptor details to edit the project with
      */

--- a/src/main/java/seedu/address/logic/parser/EditEmployeeCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditEmployeeCommandParser.java
@@ -39,7 +39,8 @@ public class EditEmployeeCommandParser implements Parser<EditEmployeeCommand> {
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditEmployeeCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    EditEmployeeCommand.MESSAGE_USAGE), pe);
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS);

--- a/src/main/java/seedu/address/logic/parser/EditEmployeeCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditEmployeeCommandParser.java
@@ -14,22 +14,22 @@ import java.util.Optional;
 import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
-import seedu.address.logic.commands.EditCommand;
-import seedu.address.logic.commands.EditCommand.EditEmployeeDescriptor;
+import seedu.address.logic.commands.EditEmployeeCommand;
+import seedu.address.logic.commands.EditEmployeeCommand.EditEmployeeDescriptor;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.tag.Tag;
 
 /**
- * Parses input arguments and creates a new EditCommand object
+ * Parses input arguments and creates a new EditEmployeeCommand object
  */
-public class EditCommandParser implements Parser<EditCommand> {
+public class EditEmployeeCommandParser implements Parser<EditEmployeeCommand> {
 
     /**
-     * Parses the given {@code String} of arguments in the context of the EditCommand
-     * and returns an EditCommand object for execution.
+     * Parses the given {@code String} of arguments in the context of the EditEmployeeCommand
+     * and returns an EditEmployeeCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
-    public EditCommand parse(String args) throws ParseException {
+    public EditEmployeeCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
@@ -39,7 +39,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditEmployeeCommand.MESSAGE_USAGE), pe);
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS);
@@ -61,10 +61,10 @@ public class EditCommandParser implements Parser<EditCommand> {
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editEmployeeDescriptor::setTags);
 
         if (!editEmployeeDescriptor.isAnyFieldEdited()) {
-            throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);
+            throw new ParseException(EditEmployeeCommand.MESSAGE_NOT_EDITED);
         }
 
-        return new EditCommand(index, editEmployeeDescriptor);
+        return new EditEmployeeCommand(index, editEmployeeDescriptor);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/EditProjectCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditProjectCommandParser.java
@@ -1,0 +1,51 @@
+package seedu.address.logic.parser;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.EditProjectCommand;
+import seedu.address.logic.commands.EditProjectCommand.EditProjectDescriptor;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DEADLINE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PRIORITY;
+
+public class EditProjectCommandParser implements Parser<EditProjectCommand> {
+
+    public EditProjectCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PRIORITY, PREFIX_DEADLINE);
+
+        Index index;
+
+        try {
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    EditProjectCommand.MESSAGE_USAGE), pe);
+        }
+
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PRIORITY, PREFIX_DEADLINE);
+
+        EditProjectDescriptor editProjectDescriptor = new EditProjectDescriptor();
+
+        if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
+            editProjectDescriptor.setName(ParserUtil.parseProject(argMultimap.getValue(PREFIX_NAME).get()).getName());
+        }
+        if (argMultimap.getValue(PREFIX_PRIORITY).isPresent()) {
+            editProjectDescriptor.setPriority(ParserUtil.parseProjectPriority(argMultimap
+                    .getValue(PREFIX_PRIORITY).get()));
+        }
+        if (argMultimap.getValue(PREFIX_DEADLINE).isPresent()) {
+            editProjectDescriptor.setDeadline(ParserUtil.parseDeadline(argMultimap
+                    .getValue(PREFIX_DEADLINE).get()));
+        }
+
+        if (!editProjectDescriptor.isAnyFieldEdited()) {
+            throw new ParseException(EditProjectCommand.MESSAGE_NOT_EDITED);
+        }
+
+        return new EditProjectCommand(index, editProjectDescriptor);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/EditProjectCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditProjectCommandParser.java
@@ -1,18 +1,26 @@
 package seedu.address.logic.parser;
 
-import seedu.address.commons.core.index.Index;
-import seedu.address.logic.commands.EditProjectCommand;
-import seedu.address.logic.commands.EditProjectCommand.EditProjectDescriptor;
-import seedu.address.logic.parser.exceptions.ParseException;
-
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DEADLINE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PRIORITY;
 
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.EditProjectCommand;
+import seedu.address.logic.commands.EditProjectCommand.EditProjectDescriptor;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new EditProjectCommand object
+ */
 public class EditProjectCommandParser implements Parser<EditProjectCommand> {
 
+    /**
+     * Parses the given {@code String} of arguments in the context of the EditProjectCommand
+     * and returns an EditProjectCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
     public EditProjectCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PRIORITY, PREFIX_DEADLINE);

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -134,8 +134,9 @@ public class ParserUtil {
     public static Project parseProject(String project) throws ParseException {
         requireNonNull(project);
         String trimmedProject = project.trim();
-        if (!Project.isValidProject(trimmedProject)) {
-            throw new ParseException(Project.MESSAGE_CONSTRAINTS);
+        // Fully qualified name used for clarity as Employee model has a Name class as well
+        if (!seedu.address.model.project.Name.isValidName(trimmedProject)) {
+            throw new ParseException(seedu.address.model.project.Name.MESSAGE_CONSTRAINTS);
         }
         return new Project(trimmedProject);
     }

--- a/src/main/java/seedu/address/logic/parser/ProjectDeadlineCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ProjectDeadlineCommandParser.java
@@ -30,6 +30,7 @@ public class ProjectDeadlineCommandParser implements Parser<ProjectDeadlineComma
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     ProjectDeadlineCommand.MESSAGE_USAGE));
         }
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_DEADLINE);
 
         Index index;
         try {

--- a/src/main/java/seedu/address/logic/parser/TaskHubParser.java
+++ b/src/main/java/seedu/address/logic/parser/TaskHubParser.java
@@ -18,7 +18,7 @@ import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteEmployeeCommand;
 import seedu.address.logic.commands.DeleteProjectCommand;
 import seedu.address.logic.commands.DeleteTaskCommand;
-import seedu.address.logic.commands.EditCommand;
+import seedu.address.logic.commands.EditEmployeeCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindEmployeeCommand;
 import seedu.address.logic.commands.FindProjectCommand;
@@ -77,8 +77,8 @@ public class TaskHubParser {
         case AddProjectCommand.COMMAND_WORD:
             return new AddProjectCommandParser().parse(arguments);
 
-        case EditCommand.COMMAND_WORD:
-            return new EditCommandParser().parse(arguments);
+        case EditEmployeeCommand.COMMAND_WORD:
+            return new EditEmployeeCommandParser().parse(arguments);
 
         case AssignProjectCommand.COMMAND_WORD:
             return new AssignProjectCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/TaskHubParser.java
+++ b/src/main/java/seedu/address/logic/parser/TaskHubParser.java
@@ -19,6 +19,7 @@ import seedu.address.logic.commands.DeleteEmployeeCommand;
 import seedu.address.logic.commands.DeleteProjectCommand;
 import seedu.address.logic.commands.DeleteTaskCommand;
 import seedu.address.logic.commands.EditEmployeeCommand;
+import seedu.address.logic.commands.EditProjectCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindEmployeeCommand;
 import seedu.address.logic.commands.FindProjectCommand;
@@ -80,6 +81,9 @@ public class TaskHubParser {
 
         case EditEmployeeCommand.COMMAND_WORD:
             return new EditEmployeeCommandParser().parse(arguments);
+
+        case EditProjectCommand.COMMAND_WORD:
+            return new EditProjectCommandParser().parse(arguments);
 
         case AssignProjectCommand.COMMAND_WORD:
             return new AssignProjectCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/model/project/Project.java
+++ b/src/main/java/seedu/address/model/project/Project.java
@@ -17,12 +17,6 @@ public class Project {
 
     public static final String MESSAGE_CONSTRAINTS = "Projects can take any values, and it should not be blank";
 
-    /*
-     * The first character must not be a whitespace,
-     * otherwise " " (a blank string) becomes a valid input.
-     */
-    public static final String VALIDATION_REGEX = "[^\\s].*";
-
     private final Name name;
     private final UniqueEmployeeList employeeList;
     private final TaskList tasks;
@@ -124,8 +118,13 @@ public class Project {
     /**
      * Returns true if a given string is a valid project name.
      */
-    public static boolean isValidProject(String test) {
-        return test.matches(VALIDATION_REGEX);
+    public static boolean isValidProjectName (String test) {
+        try {
+            Name name = new Name(test);
+            return true;
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
     }
 
     /**

--- a/src/main/java/seedu/address/model/project/Project.java
+++ b/src/main/java/seedu/address/model/project/Project.java
@@ -118,9 +118,9 @@ public class Project {
     /**
      * Returns true if a given string is a valid project name.
      */
-    public static boolean isValidProjectName (String test) {
+    public static boolean isValidProjectName(String test) {
         try {
-            Name name = new Name(test);
+            new Name(test);
             return true;
         } catch (IllegalArgumentException e) {
             return false;

--- a/src/main/java/seedu/address/storage/JsonAdaptedProject.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedProject.java
@@ -99,7 +99,7 @@ public class JsonAdaptedProject {
         if (name == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName()));
         }
-        if (!Project.isValidProject(name)) {
+        if (!Project.isValidProjectName(name)) {
             throw new IllegalValueException(Project.MESSAGE_CONSTRAINTS);
         }
         final Name modelName = new Name(name);

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -26,6 +26,7 @@ import seedu.address.model.employee.EmployeeNameContainsKeywordsPredicate;
 import seedu.address.model.project.Project;
 import seedu.address.model.project.ProjectNameContainsKeywordsPredicate;
 import seedu.address.testutil.EditEmployeeDescriptorBuilder;
+import seedu.address.testutil.EditProjectDescriptorBuilder;
 
 /**
  * Contains helper methods for testing commands.
@@ -41,14 +42,14 @@ public class CommandTestUtil {
     public static final String VALID_EMAIL_BOB = "bob@example.com";
     public static final String VALID_ADDRESS_AMY = "Block 312, Amy Street 1";
     public static final String VALID_ADDRESS_BOB = "Block 123, Bobby Street 3";
-    public static final String VALID_PROJECT_AMY = "Alpha";
-    public static final String VALID_PROJECT_BOB = "Beta";
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";
 
     // Project valid fields
-    public static final String VALID_DEADLINE_PROJECT_AMY = "21/02/2021";
-    public static final String VALID_DEADLINE_PROJECT_BOB = "15/11/2024";
+    public static final String VALID_PROJECT_AMY = "Alpha";
+    public static final String VALID_PROJECT_BOB = "Beta";
+    public static final String VALID_DEADLINE_PROJECT_AMY = "21-02-2021";
+    public static final String VALID_DEADLINE_PROJECT_BOB = "15-11-2024";
     public static final String VALID_PRIORITY_AMY = "high";
 
     // Task valid fields
@@ -70,19 +71,25 @@ public class CommandTestUtil {
     public static final String ADDRESS_DESC_BOB = " " + PREFIX_ADDRESS + VALID_ADDRESS_BOB;
     public static final String TAG_DESC_FRIEND = " " + PREFIX_TAG + VALID_TAG_FRIEND;
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
-    public static final String PROJECT_DESC_AMY = " " + PREFIX_NAME + VALID_PROJECT_AMY;
-    public static final String PROJECT_DESC_BOB = " " + PREFIX_NAME + VALID_PROJECT_BOB;
-    public static final String PROJECT_PRIORITY_AMY = " " + PREFIX_PRIORITY + VALID_PRIORITY_AMY;
 
     // Project field descriptions
-    public static final String DEADLINE_PROJECT_DESC_AMY = " " + PREFIX_DEADLINE + VALID_DEADLINE_PROJECT_AMY;
-    public static final String DEADLINE_PROJECT_DESC_BOB = " " + PREFIX_DEADLINE + VALID_DEADLINE_PROJECT_BOB;
+    public static final String PROJECT_DESC_AMY = " " + PREFIX_NAME + VALID_PROJECT_AMY;
+    public static final String PROJECT_DESC_BOB = " " + PREFIX_NAME + VALID_PROJECT_BOB;
+    public static final String PROJECT_PRIORITY_DESC_AMY = " " + PREFIX_PRIORITY + VALID_PRIORITY_AMY;
+    public static final String PROJECT_DEADLINE_DESC_AMY = " " + PREFIX_DEADLINE + VALID_DEADLINE_PROJECT_AMY;
+    public static final String PROJECT_DEADLINE_DESC_BOB = " " + PREFIX_DEADLINE + VALID_DEADLINE_PROJECT_BOB;
 
+    // Invalid Employee field descriptions
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
     public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones
     public static final String INVALID_EMAIL_DESC = " " + PREFIX_EMAIL + "bob!yahoo"; // missing '@' symbol
     public static final String INVALID_ADDRESS_DESC = " " + PREFIX_ADDRESS; // empty string not allowed for addresses
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
+
+    // Invalid Project field descriptions
+    public static final String INVALID_PROJECT_NAME_DESC = " " + PREFIX_NAME + "Alpha&"; // '&' not allowed in names
+    public static final String INVALID_PROJECT_DEADLINE_DESC = " " + PREFIX_DEADLINE + "11-11-2023 2359"; // '2359'
+    public static final String INVALID_PROJECT_PRIORITY_DESC = " " + PREFIX_PRIORITY + "high!"; // '!' not allowed
 
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";
@@ -96,6 +103,8 @@ public class CommandTestUtil {
 
     public static final EditEmployeeCommand.EditEmployeeDescriptor DESC_AMY;
     public static final EditEmployeeCommand.EditEmployeeDescriptor DESC_BOB;
+    public static final EditProjectCommand.EditProjectDescriptor DESC_PROJECT_AMY;
+    public static final EditProjectCommand.EditProjectDescriptor DESC_PROJECT_BOB;
 
     static {
         DESC_AMY = new EditEmployeeDescriptorBuilder().withName(VALID_NAME_AMY)
@@ -104,6 +113,10 @@ public class CommandTestUtil {
         DESC_BOB = new EditEmployeeDescriptorBuilder().withName(VALID_NAME_BOB)
                 .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB)
                 .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
+        DESC_PROJECT_AMY = new EditProjectDescriptorBuilder().withName(VALID_PROJECT_AMY)
+                .withDeadline(VALID_DEADLINE_PROJECT_AMY).withPriority(VALID_PRIORITY_AMY).build();
+        DESC_PROJECT_BOB = new EditProjectDescriptorBuilder().withName(VALID_PROJECT_BOB)
+                .withDeadline(VALID_DEADLINE_PROJECT_BOB).withPriority(VALID_PRIORITY_AMY).build();
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -91,8 +91,8 @@ public class CommandTestUtil {
                                                              + PREFIX_DEADLINE + VALID_DEADLINE_TASK + " ";
 
 
-    public static final EditCommand.EditEmployeeDescriptor DESC_AMY;
-    public static final EditCommand.EditEmployeeDescriptor DESC_BOB;
+    public static final EditEmployeeCommand.EditEmployeeDescriptor DESC_AMY;
+    public static final EditEmployeeCommand.EditEmployeeDescriptor DESC_BOB;
 
     static {
         DESC_AMY = new EditEmployeeDescriptorBuilder().withName(VALID_NAME_AMY)

--- a/src/test/java/seedu/address/logic/commands/EditEmployeeCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditEmployeeCommandTest.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
-import seedu.address.logic.commands.EditCommand.EditEmployeeDescriptor;
+import seedu.address.logic.commands.EditEmployeeCommand.EditEmployeeDescriptor;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.TaskHub;
@@ -29,9 +29,9 @@ import seedu.address.testutil.EditEmployeeDescriptorBuilder;
 import seedu.address.testutil.EmployeeBuilder;
 
 /**
- * Contains integration tests (interaction with the Model) and unit tests for EditCommand.
+ * Contains integration tests (interaction with the Model) and unit tests for EditEmployeeCommand.
  */
-public class EditCommandTest {
+public class EditEmployeeCommandTest {
 
     private Model model = new ModelManager(getTypicalTaskHub(), new UserPrefs());
 
@@ -39,15 +39,15 @@ public class EditCommandTest {
     public void execute_allFieldsSpecifiedUnfilteredList_success() {
         Employee editedEmployee = new EmployeeBuilder().build();
         EditEmployeeDescriptor descriptor = new EditEmployeeDescriptorBuilder(editedEmployee).build();
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_EMPLOYEE, descriptor);
+        EditEmployeeCommand editEmployeeCommand = new EditEmployeeCommand(INDEX_FIRST_EMPLOYEE, descriptor);
 
-        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_EMPLOYEE_SUCCESS,
+        String expectedMessage = String.format(EditEmployeeCommand.MESSAGE_EDIT_EMPLOYEE_SUCCESS,
                 Messages.format(editedEmployee));
 
         Model expectedModel = new ModelManager(new TaskHub(model.getTaskHub()), new UserPrefs());
         expectedModel.setEmployee(model.getFilteredEmployeeList().get(0), editedEmployee);
 
-        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(editEmployeeCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
@@ -61,28 +61,28 @@ public class EditCommandTest {
 
         EditEmployeeDescriptor descriptor = new EditEmployeeDescriptorBuilder().withName(VALID_NAME_BOB)
                 .withPhone(VALID_PHONE_BOB).withTags(VALID_TAG_HUSBAND).build();
-        EditCommand editCommand = new EditCommand(indexLastEmployee, descriptor);
+        EditEmployeeCommand editEmployeeCommand = new EditEmployeeCommand(indexLastEmployee, descriptor);
 
-        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_EMPLOYEE_SUCCESS,
+        String expectedMessage = String.format(EditEmployeeCommand.MESSAGE_EDIT_EMPLOYEE_SUCCESS,
                 Messages.format(editedEmployee));
 
         Model expectedModel = new ModelManager(new TaskHub(model.getTaskHub()), new UserPrefs());
         expectedModel.setEmployee(lastEmployee, editedEmployee);
 
-        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(editEmployeeCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
     public void execute_noFieldSpecifiedUnfilteredList_success() {
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_EMPLOYEE, new EditEmployeeDescriptor());
+        EditEmployeeCommand editEmployeeCommand = new EditEmployeeCommand(INDEX_FIRST_EMPLOYEE, new EditEmployeeDescriptor());
         Employee editedEmployee = model.getFilteredEmployeeList().get(INDEX_FIRST_EMPLOYEE.getZeroBased());
 
-        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_EMPLOYEE_SUCCESS,
+        String expectedMessage = String.format(EditEmployeeCommand.MESSAGE_EDIT_EMPLOYEE_SUCCESS,
                 Messages.format(editedEmployee));
 
         Model expectedModel = new ModelManager(new TaskHub(model.getTaskHub()), new UserPrefs());
 
-        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(editEmployeeCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
@@ -91,25 +91,25 @@ public class EditCommandTest {
 
         Employee employeeInFilteredList = model.getFilteredEmployeeList().get(INDEX_FIRST_EMPLOYEE.getZeroBased());
         Employee editedEmployee = new EmployeeBuilder(employeeInFilteredList).withName(VALID_NAME_BOB).build();
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_EMPLOYEE,
+        EditEmployeeCommand editEmployeeCommand = new EditEmployeeCommand(INDEX_FIRST_EMPLOYEE,
                 new EditEmployeeDescriptorBuilder().withName(VALID_NAME_BOB).build());
 
-        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_EMPLOYEE_SUCCESS,
+        String expectedMessage = String.format(EditEmployeeCommand.MESSAGE_EDIT_EMPLOYEE_SUCCESS,
                 Messages.format(editedEmployee));
 
         Model expectedModel = new ModelManager(new TaskHub(model.getTaskHub()), new UserPrefs());
         expectedModel.setEmployee(model.getFilteredEmployeeList().get(0), editedEmployee);
 
-        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(editEmployeeCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
     public void execute_duplicateEmployeeUnfilteredList_failure() {
         Employee firstEmployee = model.getFilteredEmployeeList().get(INDEX_FIRST_EMPLOYEE.getZeroBased());
         EditEmployeeDescriptor descriptor = new EditEmployeeDescriptorBuilder(firstEmployee).build();
-        EditCommand editCommand = new EditCommand(INDEX_SECOND_EMPLOYEE, descriptor);
+        EditEmployeeCommand editEmployeeCommand = new EditEmployeeCommand(INDEX_SECOND_EMPLOYEE, descriptor);
 
-        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_EMPLOYEE);
+        assertCommandFailure(editEmployeeCommand, model, EditEmployeeCommand.MESSAGE_DUPLICATE_EMPLOYEE);
     }
 
     @Test
@@ -118,19 +118,19 @@ public class EditCommandTest {
 
         // edit employee in filtered list into a duplicate in TaskHub
         Employee employeeInList = model.getTaskHub().getEmployeeList().get(INDEX_SECOND_EMPLOYEE.getZeroBased());
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_EMPLOYEE,
+        EditEmployeeCommand editEmployeeCommand = new EditEmployeeCommand(INDEX_FIRST_EMPLOYEE,
                 new EditEmployeeDescriptorBuilder(employeeInList).build());
 
-        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_EMPLOYEE);
+        assertCommandFailure(editEmployeeCommand, model, EditEmployeeCommand.MESSAGE_DUPLICATE_EMPLOYEE);
     }
 
     @Test
     public void execute_invalidEmployeeIndexUnfilteredList_failure() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredEmployeeList().size() + 1);
         EditEmployeeDescriptor descriptor = new EditEmployeeDescriptorBuilder().withName(VALID_NAME_BOB).build();
-        EditCommand editCommand = new EditCommand(outOfBoundIndex, descriptor);
+        EditEmployeeCommand editEmployeeCommand = new EditEmployeeCommand(outOfBoundIndex, descriptor);
 
-        assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_EMPLOYEE_DISPLAYED_INDEX);
+        assertCommandFailure(editEmployeeCommand, model, Messages.MESSAGE_INVALID_EMPLOYEE_DISPLAYED_INDEX);
     }
 
     /**
@@ -144,19 +144,19 @@ public class EditCommandTest {
         // ensures that outOfBoundIndex is still in bounds of TaskHub list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getTaskHub().getEmployeeList().size());
 
-        EditCommand editCommand = new EditCommand(outOfBoundIndex,
+        EditEmployeeCommand editEmployeeCommand = new EditEmployeeCommand(outOfBoundIndex,
                 new EditEmployeeDescriptorBuilder().withName(VALID_NAME_BOB).build());
 
-        assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_EMPLOYEE_DISPLAYED_INDEX);
+        assertCommandFailure(editEmployeeCommand, model, Messages.MESSAGE_INVALID_EMPLOYEE_DISPLAYED_INDEX);
     }
 
     @Test
     public void equals() {
-        final EditCommand standardCommand = new EditCommand(INDEX_FIRST_EMPLOYEE, DESC_AMY);
+        final EditEmployeeCommand standardCommand = new EditEmployeeCommand(INDEX_FIRST_EMPLOYEE, DESC_AMY);
 
         // same values -> returns true
         EditEmployeeDescriptor copyDescriptor = new EditEmployeeDescriptor(DESC_AMY);
-        EditCommand commandWithSameValues = new EditCommand(INDEX_FIRST_EMPLOYEE, copyDescriptor);
+        EditEmployeeCommand commandWithSameValues = new EditEmployeeCommand(INDEX_FIRST_EMPLOYEE, copyDescriptor);
         assertTrue(standardCommand.equals(commandWithSameValues));
 
         // same object -> returns true
@@ -169,20 +169,20 @@ public class EditCommandTest {
         assertFalse(standardCommand.equals(new ClearCommand()));
 
         // different index -> returns false
-        assertFalse(standardCommand.equals(new EditCommand(INDEX_SECOND_EMPLOYEE, DESC_AMY)));
+        assertFalse(standardCommand.equals(new EditEmployeeCommand(INDEX_SECOND_EMPLOYEE, DESC_AMY)));
 
         // different descriptor -> returns false
-        assertFalse(standardCommand.equals(new EditCommand(INDEX_FIRST_EMPLOYEE, DESC_BOB)));
+        assertFalse(standardCommand.equals(new EditEmployeeCommand(INDEX_FIRST_EMPLOYEE, DESC_BOB)));
     }
 
     @Test
     public void toStringMethod() {
         Index index = Index.fromOneBased(1);
         EditEmployeeDescriptor editEmployeeDescriptor = new EditEmployeeDescriptor();
-        EditCommand editCommand = new EditCommand(index, editEmployeeDescriptor);
-        String expected = EditCommand.class.getCanonicalName() + "{index=" + index + ", editEmployeeDescriptor="
+        EditEmployeeCommand editEmployeeCommand = new EditEmployeeCommand(index, editEmployeeDescriptor);
+        String expected = EditEmployeeCommand.class.getCanonicalName() + "{index=" + index + ", editEmployeeDescriptor="
                 + editEmployeeDescriptor + "}";
-        assertEquals(expected, editCommand.toString());
+        assertEquals(expected, editEmployeeCommand.toString());
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/EditEmployeeCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditEmployeeCommandTest.java
@@ -74,7 +74,8 @@ public class EditEmployeeCommandTest {
 
     @Test
     public void execute_noFieldSpecifiedUnfilteredList_success() {
-        EditEmployeeCommand editEmployeeCommand = new EditEmployeeCommand(INDEX_FIRST_EMPLOYEE, new EditEmployeeDescriptor());
+        EditEmployeeCommand editEmployeeCommand = new EditEmployeeCommand(INDEX_FIRST_EMPLOYEE,
+                new EditEmployeeDescriptor());
         Employee editedEmployee = model.getFilteredEmployeeList().get(INDEX_FIRST_EMPLOYEE.getZeroBased());
 
         String expectedMessage = String.format(EditEmployeeCommand.MESSAGE_EDIT_EMPLOYEE_SUCCESS,

--- a/src/test/java/seedu/address/logic/commands/EditEmployeeDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditEmployeeDescriptorTest.java
@@ -13,7 +13,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.logic.commands.EditCommand.EditEmployeeDescriptor;
+import seedu.address.logic.commands.EditEmployeeCommand.EditEmployeeDescriptor;
 import seedu.address.testutil.EditEmployeeDescriptorBuilder;
 
 public class EditEmployeeDescriptorTest {

--- a/src/test/java/seedu/address/logic/commands/EditProjectCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditProjectCommandTest.java
@@ -1,0 +1,192 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.DESC_PROJECT_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.DESC_PROJECT_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_DEADLINE_PROJECT_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_DEADLINE_PROJECT_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_PRIORITY_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showProjectAtIndex;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PROJECT;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PROJECT;
+import static seedu.address.testutil.TypicalProjects.getTypicalTaskHub;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.EditProjectCommand.EditProjectDescriptor;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.TaskHub;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.project.Project;
+import seedu.address.testutil.EditProjectDescriptorBuilder;
+import seedu.address.testutil.ProjectBuilder;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for EditProjectCommand.
+ */
+public class EditProjectCommandTest {
+
+    private Model model = new ModelManager(getTypicalTaskHub(), new UserPrefs());
+
+    @Test
+    public void execute_allFieldsSpecifiedUnfilteredList_success() {
+        Project editedProject = new ProjectBuilder().build();
+        EditProjectDescriptor descriptor = new EditProjectDescriptorBuilder(editedProject).build();
+        EditProjectCommand editProjectCommand = new EditProjectCommand(INDEX_FIRST_PROJECT, descriptor);
+
+        String expectedMessage = String.format(EditProjectCommand.MESSAGE_EDIT_PROJECT_SUCCESS,
+                Messages.format(editedProject));
+
+        Model expectedModel = new ModelManager(new TaskHub(model.getTaskHub()), new UserPrefs());
+        expectedModel.setProject(model.getFilteredProjectList().get(0), editedProject);
+
+        assertCommandSuccess(editProjectCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_someFieldsSpecifiedUnfilteredList_success() {
+        Index indexLastProject = Index.fromOneBased(model.getFilteredProjectList().size());
+        Project lastProject = model.getFilteredProjectList().get(indexLastProject.getZeroBased());
+
+        ProjectBuilder projectInList = new ProjectBuilder(lastProject);
+        Project editedProject = projectInList.withName(VALID_NAME_AMY).withPriority(VALID_PRIORITY_AMY)
+                .withDeadline(VALID_DEADLINE_PROJECT_AMY).build();
+
+        EditProjectDescriptor descriptor = new EditProjectDescriptorBuilder().withName(VALID_NAME_AMY)
+                .withPriority(VALID_PRIORITY_AMY).withDeadline(VALID_DEADLINE_PROJECT_AMY).build();
+        EditProjectCommand editProjectCommand = new EditProjectCommand(indexLastProject, descriptor);
+
+        String expectedMessage = String.format(EditProjectCommand.MESSAGE_EDIT_PROJECT_SUCCESS,
+                Messages.format(editedProject));
+
+        Model expectedModel = new ModelManager(new TaskHub(model.getTaskHub()), new UserPrefs());
+        expectedModel.setProject(lastProject, editedProject);
+
+        assertCommandSuccess(editProjectCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_noFieldSpecifiedUnfilteredList_success() {
+        EditProjectCommand editProjectCommand = new EditProjectCommand(INDEX_FIRST_PROJECT, new EditProjectDescriptor());
+        Project editedProject = model.getFilteredProjectList().get(INDEX_FIRST_PROJECT.getZeroBased());
+
+        String expectedMessage = String.format(EditProjectCommand.MESSAGE_EDIT_PROJECT_SUCCESS,
+                Messages.format(editedProject));
+
+        Model expectedModel = new ModelManager(new TaskHub(model.getTaskHub()), new UserPrefs());
+
+        assertCommandSuccess(editProjectCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_filteredList_success() {
+        showProjectAtIndex(model, INDEX_FIRST_PROJECT);
+
+        Project projectInFilteredList = model.getFilteredProjectList().get(INDEX_FIRST_PROJECT.getZeroBased());
+        Project editedProject = new ProjectBuilder(projectInFilteredList).withName(VALID_NAME_AMY)
+                .withPriority(VALID_PRIORITY_AMY).withDeadline(VALID_DEADLINE_PROJECT_AMY).build();
+        EditProjectCommand editProjectCommand = new EditProjectCommand(INDEX_FIRST_PROJECT,
+                new EditProjectDescriptorBuilder().withName(VALID_NAME_AMY)
+                        .withPriority(VALID_PRIORITY_AMY).withDeadline(VALID_DEADLINE_PROJECT_AMY).build());
+
+        String expectedMessage = String.format(EditProjectCommand.MESSAGE_EDIT_PROJECT_SUCCESS,
+                Messages.format(editedProject));
+
+        Model expectedModel = new ModelManager(new TaskHub(model.getTaskHub()), new UserPrefs());
+        expectedModel.setProject(model.getFilteredProjectList().get(0), editedProject);
+
+        assertCommandSuccess(editProjectCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_duplicateProjectUnfilteredList_failure() {
+        Project firstProject = model.getFilteredProjectList().get(INDEX_FIRST_PROJECT.getZeroBased());
+        EditProjectDescriptor descriptor = new EditProjectDescriptorBuilder(firstProject).build();
+        EditProjectCommand editProjectCommand = new EditProjectCommand(INDEX_SECOND_PROJECT, descriptor);
+
+        assertCommandFailure(editProjectCommand, model, EditProjectCommand.MESSAGE_DUPLICATE_PROJECT);
+    }
+
+    @Test
+    public void execute_duplicateProjectFilteredList_failure() {
+        showProjectAtIndex(model, INDEX_FIRST_PROJECT);
+
+        // edit project in filtered list into a duplicate in TaskHub
+        Project projectInList = model.getTaskHub().getProjectList().get(INDEX_SECOND_PROJECT.getZeroBased());
+        EditProjectCommand editProjectCommand = new EditProjectCommand(INDEX_FIRST_PROJECT,
+                new EditProjectDescriptorBuilder(projectInList).build());
+
+        assertCommandFailure(editProjectCommand, model, EditProjectCommand.MESSAGE_DUPLICATE_PROJECT);
+    }
+
+    @Test
+    public void execute_invalidProjectIndexUnfilteredList_failure() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredProjectList().size() + 1);
+        EditProjectDescriptor descriptor = new EditProjectDescriptorBuilder().withName(VALID_NAME_AMY).build();
+        EditProjectCommand editProjectCommand = new EditProjectCommand(outOfBoundIndex, descriptor);
+
+        assertCommandFailure(editProjectCommand, model, Messages.MESSAGE_INVALID_PROJECT_DISPLAYED_INDEX);
+    }
+
+    /**
+     * Edit filtered list where index is larger than size of filtered list,
+     * but smaller than size of TaskHub
+     */
+    @Test
+    public void execute_invalidProjectIndexFilteredList_failure() {
+        showProjectAtIndex(model, INDEX_FIRST_PROJECT);
+        Index outOfBoundIndex = INDEX_SECOND_PROJECT;
+        // ensures that outOfBoundIndex is still in bounds of TaskHub list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getTaskHub().getProjectList().size());
+
+        EditProjectCommand editProjectCommand = new EditProjectCommand(outOfBoundIndex,
+                new EditProjectDescriptorBuilder().withName(VALID_NAME_AMY).build());
+
+        assertCommandFailure(editProjectCommand, model, Messages.MESSAGE_INVALID_PROJECT_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        final EditProjectCommand standardCommand = new EditProjectCommand(INDEX_FIRST_PROJECT, DESC_PROJECT_AMY);
+
+        // same values -> returns true
+        EditProjectDescriptor copyDescriptor = new EditProjectDescriptor(DESC_PROJECT_AMY);
+        EditProjectCommand commandWithSameValues = new EditProjectCommand(INDEX_FIRST_PROJECT, copyDescriptor);
+        assertTrue(standardCommand.equals(commandWithSameValues));
+
+        // same object -> returns true
+        assertTrue(standardCommand.equals(standardCommand));
+
+        // null -> returns false
+        assertFalse(standardCommand.equals(null));
+
+        // different types -> returns false
+        assertFalse(standardCommand.equals(new ClearCommand()));
+
+        // different index -> returns false
+        assertFalse(standardCommand.equals(new EditProjectCommand(INDEX_SECOND_PROJECT, DESC_PROJECT_AMY)));
+
+        // different descriptor -> returns false
+        assertFalse(standardCommand.equals(new EditProjectCommand(INDEX_FIRST_PROJECT, DESC_PROJECT_BOB)));
+    }
+
+    @Test
+    public void toStringMethod() {
+        Index index = Index.fromOneBased(1);
+        EditProjectDescriptor editProjectDescriptor = new EditProjectDescriptor();
+        EditProjectCommand editProjectCommand = new EditProjectCommand(index, editProjectDescriptor);
+        String expected = EditProjectCommand.class.getCanonicalName() + "{index=" + index + ", editProjectDescriptor="
+                + editProjectDescriptor + "}";
+        assertEquals(expected, editProjectCommand.toString());
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/EditProjectCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditProjectCommandTest.java
@@ -3,11 +3,8 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.commands.CommandTestUtil.DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_PROJECT_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_PROJECT_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_DEADLINE_PROJECT_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_DEADLINE_PROJECT_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PRIORITY_AMY;
@@ -39,21 +36,6 @@ public class EditProjectCommandTest {
     private Model model = new ModelManager(getTypicalTaskHub(), new UserPrefs());
 
     @Test
-    public void execute_allFieldsSpecifiedUnfilteredList_success() {
-        Project editedProject = new ProjectBuilder().build();
-        EditProjectDescriptor descriptor = new EditProjectDescriptorBuilder(editedProject).build();
-        EditProjectCommand editProjectCommand = new EditProjectCommand(INDEX_FIRST_PROJECT, descriptor);
-
-        String expectedMessage = String.format(EditProjectCommand.MESSAGE_EDIT_PROJECT_SUCCESS,
-                Messages.format(editedProject));
-
-        Model expectedModel = new ModelManager(new TaskHub(model.getTaskHub()), new UserPrefs());
-        expectedModel.setProject(model.getFilteredProjectList().get(0), editedProject);
-
-        assertCommandSuccess(editProjectCommand, model, expectedMessage, expectedModel);
-    }
-
-    @Test
     public void execute_someFieldsSpecifiedUnfilteredList_success() {
         Index indexLastProject = Index.fromOneBased(model.getFilteredProjectList().size());
         Project lastProject = model.getFilteredProjectList().get(indexLastProject.getZeroBased());
@@ -77,7 +59,8 @@ public class EditProjectCommandTest {
 
     @Test
     public void execute_noFieldSpecifiedUnfilteredList_success() {
-        EditProjectCommand editProjectCommand = new EditProjectCommand(INDEX_FIRST_PROJECT, new EditProjectDescriptor());
+        EditProjectCommand editProjectCommand = new EditProjectCommand(INDEX_FIRST_PROJECT,
+                new EditProjectDescriptor());
         Project editedProject = model.getFilteredProjectList().get(INDEX_FIRST_PROJECT.getZeroBased());
 
         String expectedMessage = String.format(EditProjectCommand.MESSAGE_EDIT_PROJECT_SUCCESS,

--- a/src/test/java/seedu/address/logic/parser/EditEmployeeCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditEmployeeCommandParserTest.java
@@ -36,8 +36,8 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
-import seedu.address.logic.commands.EditCommand;
-import seedu.address.logic.commands.EditCommand.EditEmployeeDescriptor;
+import seedu.address.logic.commands.EditEmployeeCommand;
+import seedu.address.logic.commands.EditEmployeeCommand.EditEmployeeDescriptor;
 import seedu.address.model.employee.Address;
 import seedu.address.model.employee.Email;
 import seedu.address.model.employee.Name;
@@ -45,14 +45,14 @@ import seedu.address.model.employee.Phone;
 import seedu.address.model.tag.Tag;
 import seedu.address.testutil.EditEmployeeDescriptorBuilder;
 
-public class EditCommandParserTest {
+public class EditEmployeeCommandParserTest {
 
     private static final String TAG_EMPTY = " " + PREFIX_TAG;
 
     private static final String MESSAGE_INVALID_FORMAT =
-            String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE);
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditEmployeeCommand.MESSAGE_USAGE);
 
-    private EditCommandParser parser = new EditCommandParser();
+    private EditEmployeeCommandParser parser = new EditEmployeeCommandParser();
 
     @Test
     public void parse_missingParts_failure() {
@@ -60,7 +60,7 @@ public class EditCommandParserTest {
         assertParseFailure(parser, VALID_NAME_AMY, MESSAGE_INVALID_FORMAT);
 
         // no field specified
-        assertParseFailure(parser, "1", EditCommand.MESSAGE_NOT_EDITED);
+        assertParseFailure(parser, "1", EditEmployeeCommand.MESSAGE_NOT_EDITED);
 
         // no index and no field specified
         assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
@@ -112,7 +112,7 @@ public class EditCommandParserTest {
         EditEmployeeDescriptor descriptor = new EditEmployeeDescriptorBuilder().withName(VALID_NAME_AMY)
                 .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY)
                 .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
-        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+        EditEmployeeCommand expectedCommand = new EditEmployeeCommand(targetIndex, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
     }
@@ -124,7 +124,7 @@ public class EditCommandParserTest {
 
         EditEmployeeDescriptor descriptor = new EditEmployeeDescriptorBuilder().withPhone(VALID_PHONE_BOB)
                 .withEmail(VALID_EMAIL_AMY).build();
-        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+        EditEmployeeCommand expectedCommand = new EditEmployeeCommand(targetIndex, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
     }
@@ -135,31 +135,31 @@ public class EditCommandParserTest {
         Index targetIndex = INDEX_THIRD_EMPLOYEE;
         String userInput = targetIndex.getOneBased() + NAME_DESC_AMY;
         EditEmployeeDescriptor descriptor = new EditEmployeeDescriptorBuilder().withName(VALID_NAME_AMY).build();
-        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+        EditEmployeeCommand expectedCommand = new EditEmployeeCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // phone
         userInput = targetIndex.getOneBased() + PHONE_DESC_AMY;
         descriptor = new EditEmployeeDescriptorBuilder().withPhone(VALID_PHONE_AMY).build();
-        expectedCommand = new EditCommand(targetIndex, descriptor);
+        expectedCommand = new EditEmployeeCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // email
         userInput = targetIndex.getOneBased() + EMAIL_DESC_AMY;
         descriptor = new EditEmployeeDescriptorBuilder().withEmail(VALID_EMAIL_AMY).build();
-        expectedCommand = new EditCommand(targetIndex, descriptor);
+        expectedCommand = new EditEmployeeCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // address
         userInput = targetIndex.getOneBased() + ADDRESS_DESC_AMY;
         descriptor = new EditEmployeeDescriptorBuilder().withAddress(VALID_ADDRESS_AMY).build();
-        expectedCommand = new EditCommand(targetIndex, descriptor);
+        expectedCommand = new EditEmployeeCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // tags
         userInput = targetIndex.getOneBased() + TAG_DESC_FRIEND;
         descriptor = new EditEmployeeDescriptorBuilder().withTags(VALID_TAG_FRIEND).build();
-        expectedCommand = new EditCommand(targetIndex, descriptor);
+        expectedCommand = new EditEmployeeCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
     }
 
@@ -201,7 +201,7 @@ public class EditCommandParserTest {
         String userInput = targetIndex.getOneBased() + TAG_EMPTY;
 
         EditEmployeeDescriptor descriptor = new EditEmployeeDescriptorBuilder().withTags().build();
-        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+        EditEmployeeCommand expectedCommand = new EditEmployeeCommand(targetIndex, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
     }

--- a/src/test/java/seedu/address/logic/parser/EditProjectCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditProjectCommandParserTest.java
@@ -1,0 +1,140 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_PROJECT_DEADLINE_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_PROJECT_NAME_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_PROJECT_PRIORITY_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.PROJECT_DEADLINE_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.PROJECT_DEADLINE_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.PROJECT_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.PROJECT_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.PROJECT_PRIORITY_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_DEADLINE_PROJECT_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_PRIORITY_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_PROJECT_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_PROJECT_BOB;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DEADLINE;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PROJECT;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PROJECT;
+import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_PROJECT;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.EditProjectCommand;
+import seedu.address.logic.commands.EditProjectCommand.EditProjectDescriptor;
+import seedu.address.model.project.Deadline;
+import seedu.address.model.project.Name;
+import seedu.address.model.project.ProjectPriority;
+import seedu.address.testutil.EditProjectDescriptorBuilder;
+
+public class EditProjectCommandParserTest {
+
+    private static final String MESSAGE_INVALID_FORMAT =
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditProjectCommand.MESSAGE_USAGE);
+
+    private EditProjectCommandParser parser = new EditProjectCommandParser();
+
+    @Test
+    public void parse_missingParts_failure() {
+        // no index specified
+        assertParseFailure(parser, VALID_PROJECT_AMY, MESSAGE_INVALID_FORMAT);
+
+        // no field specified
+        assertParseFailure(parser, "1", EditProjectCommand.MESSAGE_NOT_EDITED);
+
+        // no index and no field specified
+        assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_invalidPreamble_failure() {
+        // negative index
+        assertParseFailure(parser, "-5" + PROJECT_DESC_AMY, MESSAGE_INVALID_FORMAT);
+
+        // zero index
+        assertParseFailure(parser, "0" + PROJECT_DESC_AMY, MESSAGE_INVALID_FORMAT);
+
+        // invalid arguments being parsed as preamble
+        assertParseFailure(parser, "1 some random string", MESSAGE_INVALID_FORMAT);
+
+        // invalid prefix being parsed as preamble
+        assertParseFailure(parser, "1 i/ string", MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_invalidValue_failure() {
+        // invalid name
+        assertParseFailure(parser, "1" + INVALID_PROJECT_NAME_DESC, Name.MESSAGE_CONSTRAINTS);
+
+        // invalid priority
+        assertParseFailure(parser, "1" + INVALID_PROJECT_PRIORITY_DESC, ProjectPriority.MESSAGE_CONSTRAINTS);
+
+        // invalid deadline
+        assertParseFailure(parser, "1" + INVALID_PROJECT_DEADLINE_DESC, Deadline.MESSAGE_CONSTRAINTS);
+
+        // multiple invalid values, but only the first invalid value is captured
+        assertParseFailure(parser, "1" + INVALID_PROJECT_PRIORITY_DESC + VALID_PROJECT_AMY
+                        + VALID_DEADLINE_PROJECT_AMY, ProjectPriority.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_allFieldsSpecified_success() {
+        Index targetIndex = INDEX_SECOND_PROJECT;
+        String userInput = targetIndex.getOneBased() + PROJECT_DESC_AMY + PROJECT_PRIORITY_DESC_AMY
+                + PROJECT_DEADLINE_DESC_AMY;
+
+        EditProjectDescriptor descriptor = new EditProjectDescriptorBuilder().withName(VALID_PROJECT_AMY)
+                .withPriority(VALID_PRIORITY_AMY).withDeadline(VALID_DEADLINE_PROJECT_AMY).build();
+        EditProjectCommand expectedCommand = new EditProjectCommand(targetIndex, descriptor);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_someFieldsSpecified_success() {
+        Index targetIndex = INDEX_FIRST_PROJECT;
+        String userInput = targetIndex.getOneBased() + PROJECT_DESC_BOB + PROJECT_PRIORITY_DESC_AMY;
+
+        EditProjectDescriptor descriptor = new EditProjectDescriptorBuilder().withPriority(VALID_PRIORITY_AMY)
+                .withName(VALID_PROJECT_BOB).build();
+        EditProjectCommand expectedCommand = new EditProjectCommand(targetIndex, descriptor);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_oneFieldSpecified_success() {
+        // name
+        Index targetIndex = INDEX_THIRD_PROJECT;
+        String userInput = targetIndex.getOneBased() + PROJECT_DESC_AMY;
+        EditProjectDescriptor descriptor = new EditProjectDescriptorBuilder().withName(VALID_PROJECT_AMY).build();
+        EditProjectCommand expectedCommand = new EditProjectCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        // priority
+        userInput = targetIndex.getOneBased() + PROJECT_PRIORITY_DESC_AMY;
+        descriptor = new EditProjectDescriptorBuilder().withPriority(VALID_PRIORITY_AMY).build();
+        expectedCommand = new EditProjectCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        // deadline
+        userInput = targetIndex.getOneBased() + PROJECT_DEADLINE_DESC_AMY;
+        descriptor = new EditProjectDescriptorBuilder().withDeadline(VALID_DEADLINE_PROJECT_AMY).build();
+        expectedCommand = new EditProjectCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_multipleRepeatedFields_failure() {
+        Index targetIndex = INDEX_FIRST_PROJECT;
+        String userInput = targetIndex.getOneBased() + PROJECT_DESC_AMY + PROJECT_PRIORITY_DESC_AMY
+                + PROJECT_DEADLINE_DESC_AMY + PROJECT_DEADLINE_DESC_BOB;
+
+        assertParseFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_DEADLINE));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/EditProjectCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditProjectCommandParserTest.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_PROJECT_DEADLINE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_PROJECT_NAME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_PROJECT_PRIORITY_DESC;

--- a/src/test/java/seedu/address/logic/parser/PriorityProjectCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/PriorityProjectCommandParserTest.java
@@ -1,7 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.commands.CommandTestUtil.PROJECT_PRIORITY_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.PROJECT_PRIORITY_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PRIORITY_AMY;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
@@ -19,7 +19,7 @@ public class PriorityProjectCommandParserTest {
     public void parse_allFieldsPresent_success() {
         ProjectPriority priority = new ProjectPriority("high");
         Index targetIndex = INDEX_FIRST_PROJECT;
-        String userInput = INDEX_FIRST_PROJECT.getOneBased() + PROJECT_PRIORITY_AMY;
+        String userInput = INDEX_FIRST_PROJECT.getOneBased() + PROJECT_PRIORITY_DESC_AMY;
         assertParseSuccess(parser, userInput,
                 new PriorityProjectCommand(priority, targetIndex));
     }

--- a/src/test/java/seedu/address/logic/parser/TaskHubParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/TaskHubParserTest.java
@@ -32,8 +32,8 @@ import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.DeleteEmployeeCommand;
 import seedu.address.logic.commands.DeleteProjectCommand;
 import seedu.address.logic.commands.DeleteTaskCommand;
-import seedu.address.logic.commands.EditCommand;
-import seedu.address.logic.commands.EditCommand.EditEmployeeDescriptor;
+import seedu.address.logic.commands.EditEmployeeCommand;
+import seedu.address.logic.commands.EditEmployeeCommand.EditEmployeeDescriptor;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindEmployeeCommand;
 import seedu.address.logic.commands.FindProjectCommand;
@@ -88,9 +88,9 @@ public class TaskHubParserTest {
     public void parseCommand_editEmployee() throws Exception {
         Employee employee = new EmployeeBuilder().build();
         EditEmployeeDescriptor descriptor = new EditEmployeeDescriptorBuilder(employee).build();
-        EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
+        EditEmployeeCommand command = (EditEmployeeCommand) parser.parseCommand(EditEmployeeCommand.COMMAND_WORD + " "
                 + INDEX_FIRST_EMPLOYEE.getOneBased() + " " + EmployeeUtil.getEditEmployeeDescriptorDetails(descriptor));
-        assertEquals(new EditCommand(INDEX_FIRST_EMPLOYEE, descriptor), command);
+        assertEquals(new EditEmployeeCommand(INDEX_FIRST_EMPLOYEE, descriptor), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/model/project/ProjectTest.java
+++ b/src/test/java/seedu/address/model/project/ProjectTest.java
@@ -22,15 +22,15 @@ public class ProjectTest {
     @Test
     public void isValidProject() {
         // null project
-        assertThrows(NullPointerException.class, () -> Project.isValidProject(null));
+        assertThrows(NullPointerException.class, () -> Project.isValidProjectName(null));
 
         // invalid projects
-        assertFalse(Project.isValidProject("")); // empty string
-        assertFalse(Project.isValidProject(" ")); // spaces only
+        assertFalse(Project.isValidProjectName("")); // empty string
+        assertFalse(Project.isValidProjectName(" ")); // spaces only
 
         // valid projects
-        assertTrue(Project.isValidProject("likes to study"));
-        assertTrue(Project.isValidProject("-")); // one character
+        assertTrue(Project.isValidProjectName("likes to study"));
+        assertTrue(Project.isValidProjectName("9")); // one character
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/EditEmployeeDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditEmployeeDescriptorBuilder.java
@@ -4,7 +4,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import seedu.address.logic.commands.EditCommand.EditEmployeeDescriptor;
+import seedu.address.logic.commands.EditEmployeeCommand.EditEmployeeDescriptor;
 import seedu.address.model.employee.Address;
 import seedu.address.model.employee.Email;
 import seedu.address.model.employee.Employee;

--- a/src/test/java/seedu/address/testutil/EditProjectDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditProjectDescriptorBuilder.java
@@ -7,6 +7,9 @@ import seedu.address.model.project.Name;
 import seedu.address.model.project.Project;
 import seedu.address.model.project.ProjectPriority;
 
+/**
+ * A utility class to help with building EditProjectDescriptor objects.
+ */
 public class EditProjectDescriptorBuilder {
 
     private EditProjectDescriptor descriptor;

--- a/src/test/java/seedu/address/testutil/EditProjectDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditProjectDescriptorBuilder.java
@@ -1,0 +1,59 @@
+package seedu.address.testutil;
+
+import seedu.address.logic.commands.EditProjectCommand;
+import seedu.address.logic.commands.EditProjectCommand.EditProjectDescriptor;
+import seedu.address.model.project.Deadline;
+import seedu.address.model.project.Name;
+import seedu.address.model.project.Project;
+import seedu.address.model.project.ProjectPriority;
+
+public class EditProjectDescriptorBuilder {
+
+    private EditProjectDescriptor descriptor;
+
+    public EditProjectDescriptorBuilder() {
+        descriptor = new EditProjectDescriptor();
+    }
+
+    public EditProjectDescriptorBuilder(EditProjectDescriptor descriptor) {
+        this.descriptor = new EditProjectDescriptor(descriptor);
+    }
+
+    /**
+     * Returns an {@code EditProjectDescriptor} with fields containing {@code project}'s details
+     */
+    public EditProjectDescriptorBuilder(Project project) {
+        descriptor = new EditProjectCommand.EditProjectDescriptor();
+        descriptor.setName(project.getName());
+        descriptor.setPriority(project.getProjectPriority());
+        descriptor.setDeadline(project.getDeadline());
+    }
+
+    /**
+     * Sets the {@code Name} of the {@code EditProjectDescriptor} that we are building.
+     */
+    public EditProjectDescriptorBuilder withName(String name) {
+        descriptor.setName(new Name(name));
+        return this;
+    }
+
+    /**
+     * Sets the {@code ProjectPriority} of the {@code EditProjectDescriptor} that we are building.
+     */
+    public EditProjectDescriptorBuilder withPriority(String priority) {
+        descriptor.setPriority(new ProjectPriority(priority));
+        return this;
+    }
+
+    /**
+     * Sets the {@code Deadline} of the {@code EditProjectDescriptor} that we are building.
+     */
+    public EditProjectDescriptorBuilder withDeadline(String deadline) {
+        descriptor.setDeadline(new Deadline(deadline));
+        return this;
+    }
+
+    public EditProjectDescriptor build() {
+        return descriptor;
+    }
+}

--- a/src/test/java/seedu/address/testutil/EmployeeUtil.java
+++ b/src/test/java/seedu/address/testutil/EmployeeUtil.java
@@ -9,7 +9,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import java.util.Set;
 
 import seedu.address.logic.commands.AddEmployeeCommand;
-import seedu.address.logic.commands.EditCommand.EditEmployeeDescriptor;
+import seedu.address.logic.commands.EditEmployeeCommand.EditEmployeeDescriptor;
 import seedu.address.model.employee.Employee;
 import seedu.address.model.tag.Tag;
 

--- a/src/test/java/seedu/address/testutil/ProjectBuilder.java
+++ b/src/test/java/seedu/address/testutil/ProjectBuilder.java
@@ -89,8 +89,8 @@ public class ProjectBuilder {
     /**
      * Sets the priority of the {@code Project} we are building.
      */
-    public ProjectBuilder withPriority(ProjectPriority priority) {
-        this.projectPriority = priority;
+    public ProjectBuilder withPriority(String priority) {
+        this.projectPriority = new ProjectPriority(priority);
         return this;
     }
 

--- a/src/test/java/seedu/address/testutil/TypicalProjects.java
+++ b/src/test/java/seedu/address/testutil/TypicalProjects.java
@@ -15,7 +15,6 @@ import java.util.List;
 
 import seedu.address.model.TaskHub;
 import seedu.address.model.project.Project;
-import seedu.address.model.project.ProjectPriority;
 
 /**
  * A utility class containing a list of {@code Project} objects to be used in tests.
@@ -36,13 +35,13 @@ public class TypicalProjects {
     public static final Project HIGH_PRIORITY_PROJECT = new ProjectBuilder()
             .withName("High Priority Project")
             .withTasks(ALPHA_TASK, BETA_TASK, CHARLIE_TASK)
-            .withPriority(new ProjectPriority("high"))
+            .withPriority("high")
             .build();
 
     public static final Project LOW_PRIORITY_PROJECT = new ProjectBuilder()
             .withName("Low Priority Project")
             .withTasks(ALPHA_TASK, BETA_TASK, CHARLIE_TASK)
-            .withPriority(new ProjectPriority("low"))
+            .withPriority("low")
             .build();
 
     public static final Project ASSIGNED_TASKS_PROJECT = new ProjectBuilder()


### PR DESCRIPTION
Closes #166.

Changes made:

1. Add `EditProjectCommand`
2. Change `EditCommand` -> `EditEmployeeCommand`
3. Change command word for `EditEmployeeCommand` from `edit` to `editE`

New Command: `editP`
Command usage: `editP INDEX [n/NAME] [priority/PRIORITY] [d/DEADLINE]`, and at least one field out of the three must be present.
Example: 
1. `editP 1 n/Infinity` 
2. `editP 1 d/29-10-2023 priority/low`

Yet to add in UG.