### PR TITLE
Fix storage bug

### DIFF
--- a/src/main/java/seedu/address/model/TaskHub.java
+++ b/src/main/java/seedu/address/model/TaskHub.java
@@ -94,6 +94,14 @@ public class TaskHub implements ReadOnlyTaskHub {
     }
 
     /**
+     * Returns true if a employee with all the same fields as {@code employee} exists in the TaskHub.
+     */
+    public boolean strictlyHasEmployee(Employee employee) {
+        requireNonNull(employee);
+        return employees.strictlyContains(employee);
+    }
+
+    /**
      * Adds a employee to the TaskHub.
      * The employee must not already exist in the TaskHub.
      */

--- a/src/main/java/seedu/address/model/employee/UniqueEmployeeList.java
+++ b/src/main/java/seedu/address/model/employee/UniqueEmployeeList.java
@@ -30,10 +30,20 @@ public class UniqueEmployeeList implements Iterable<Employee> {
 
     /**
      * Returns true if the list contains an equivalent employee as the given argument.
+     * (uses a weaker notion of equality)
      */
     public boolean contains(Employee toCheck) {
         requireNonNull(toCheck);
         return internalList.stream().anyMatch(toCheck::isSameEmployee);
+    }
+
+    /**
+     * Returns true if the list contains the same employee as the given argument.
+     * (uses a stronger notion of equality)
+     */
+    public boolean strictlyContains(Employee toCheck) {
+        requireNonNull(toCheck);
+        return internalList.stream().anyMatch(toCheck::equals);
     }
 
     /**

--- a/src/main/java/seedu/address/storage/JsonAdaptedProject.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedProject.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.employee.Employee;
 import seedu.address.model.employee.UniqueEmployeeList;
 import seedu.address.model.employee.exceptions.DuplicateEmployeeException;
 import seedu.address.model.project.CompletionStatus;
@@ -15,6 +16,7 @@ import seedu.address.model.project.Deadline;
 import seedu.address.model.project.Name;
 import seedu.address.model.project.Priority;
 import seedu.address.model.project.Project;
+import seedu.address.model.task.Task;
 import seedu.address.model.task.TaskList;
 
 /**
@@ -23,6 +25,7 @@ import seedu.address.model.task.TaskList;
 
 public class JsonAdaptedProject {
     public static final String MISSING_FIELD_MESSAGE_FORMAT = "Project's %s field is missing!";
+    public static final String MESSAGE_NOT_ASSIGNED_EMPLOYEE = "Employee(s) assigned to task not found in project!";
     private final String name;
     private final List<JsonAdaptedEmployee> employees = new ArrayList<>();
     private final List<JsonAdaptedTask> tasks = new ArrayList<>();
@@ -89,7 +92,13 @@ public class JsonAdaptedProject {
         final TaskList taskList = new TaskList();
         try {
             for (JsonAdaptedTask task : tasks) {
-                taskList.add(task.toModelType());
+                Task modeledTask = task.toModelType();
+                for(Employee assignedEmployee : modeledTask.getEmployee()) {
+                    if(!employeeList.strictlyContains(assignedEmployee)) {
+                        throw new IllegalValueException(MESSAGE_NOT_ASSIGNED_EMPLOYEE);
+                    }
+                }
+                taskList.add(modeledTask);
             }
         } catch (DuplicateEmployeeException e) {
             throw new IllegalValueException(e.getMessage());

--- a/src/main/java/seedu/address/storage/JsonSerializableTaskHub.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableTaskHub.java
@@ -22,6 +22,7 @@ class JsonSerializableTaskHub {
 
     public static final String MESSAGE_DUPLICATE_EMPLOYEE = "Employees list contains duplicate employee(s).";
     public static final String MESSAGE_DUPLICATE_PROJECT = "Projects list contains duplicate project(s).";
+    public static final String MESSAGE_NONEXISTENT_EMPLOYEE = "Employee(s) in project does not exist.";
 
     private final List<JsonAdaptedEmployee> employees = new ArrayList<>();
     private final List<JsonAdaptedProject> projects = new ArrayList<>();
@@ -64,6 +65,11 @@ class JsonSerializableTaskHub {
             Project project = jsonAdaptedProject.toModelType();
             if (taskHub.hasProject(project)) {
                 throw new IllegalValueException(MESSAGE_DUPLICATE_PROJECT);
+            }
+            for(Employee maybeEmployee : project.getEmployees()) {
+                if(!taskHub.strictlyHasEmployee(maybeEmployee)) {
+                    throw new IllegalValueException(MESSAGE_NONEXISTENT_EMPLOYEE);
+                }
             }
             taskHub.addProject(project);
         }

--- a/src/test/java/seedu/address/testutil/TypicalProjects.java
+++ b/src/test/java/seedu/address/testutil/TypicalProjects.java
@@ -1,5 +1,7 @@
 package seedu.address.testutil;
 
+import static seedu.address.testutil.TypicalEmployees.ALICE;
+import static seedu.address.testutil.TypicalEmployees.AMY;
 import static seedu.address.testutil.TypicalEmployees.BENSON;
 import static seedu.address.testutil.TypicalEmployees.DANIEL;
 import static seedu.address.testutil.TypicalEmployees.FIONA;
@@ -46,6 +48,7 @@ public class TypicalProjects {
 
     public static final Project ASSIGNED_TASKS_PROJECT = new ProjectBuilder()
             .withName("Project with assigned task")
+            .withEmployees(ALICE)
             .withTasks(ALPHA_TASK, DELTA_TASK)
             .build();
 

--- a/src/test/java/seedu/address/testutil/TypicalTasks.java
+++ b/src/test/java/seedu/address/testutil/TypicalTasks.java
@@ -1,7 +1,7 @@
 package seedu.address.testutil;
 
 
-import static seedu.address.testutil.TypicalEmployees.AMY;
+import static seedu.address.testutil.TypicalEmployees.ALICE;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -19,7 +19,7 @@ import seedu.address.model.task.Task;
 public class TypicalTasks {
     public static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("dd-MM-yyyy HHmm");
     public static final LocalDateTime DEFAULT_DEADLINE = LocalDateTime.parse("11-11-2023 2359", FORMATTER);
-    public static final List<Employee> DEFAULT_EMPLOYEE = Collections.singletonList(AMY);
+    public static final List<Employee> DEFAULT_EMPLOYEE = Collections.singletonList(ALICE);
 
     public static final Task ALPHA_TASK = new TaskBuilder().build();
     public static final Task BETA_TASK = new TaskBuilder().withName("Beta")


### PR DESCRIPTION
Close #207 
After this PR, users cannot modify the stored .json file to create employees that are in a project but not in the employee list, and employees that are assigned to a task in a project but not in the project itself. Doing so will return the user with an empty Taskhub.

Extra note:
A new method `strictlyContains` is implemented instead of using `contains` because a user can modify other information of an employee and cause invocation errors.

This PR may also fail CI due to the sequence of the tests executed. This is because other tests may modify `typicalTaskhub` and violate the rules of storage.