### PR TITLE
Fix storage branch

### DIFF
--- a/src/main/java/seedu/address/model/TaskHub.java
+++ b/src/main/java/seedu/address/model/TaskHub.java
@@ -94,6 +94,14 @@ public class TaskHub implements ReadOnlyTaskHub {
     }
 
     /**
+     * Returns true if a employee with all the same fields as {@code employee} exists in the TaskHub.
+     */
+    public boolean strictlyHasEmployee(Employee employee) {
+        requireNonNull(employee);
+        return employees.strictlyContains(employee);
+    }
+
+    /**
      * Adds a employee to the TaskHub.
      * The employee must not already exist in the TaskHub.
      */

--- a/src/main/java/seedu/address/model/employee/UniqueEmployeeList.java
+++ b/src/main/java/seedu/address/model/employee/UniqueEmployeeList.java
@@ -30,10 +30,20 @@ public class UniqueEmployeeList implements Iterable<Employee> {
 
     /**
      * Returns true if the list contains an equivalent employee as the given argument.
+     * (uses a weaker notion of equality)
      */
     public boolean contains(Employee toCheck) {
         requireNonNull(toCheck);
         return internalList.stream().anyMatch(toCheck::isSameEmployee);
+    }
+
+    /**
+     * Returns true if the list contains the same employee as the given argument.
+     * (uses a stronger notion of equality)
+     */
+    public boolean strictlyContains(Employee toCheck) {
+        requireNonNull(toCheck);
+        return internalList.stream().anyMatch(toCheck::equals);
     }
 
     /**

--- a/src/main/java/seedu/address/storage/JsonAdaptedProject.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedProject.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.employee.Employee;
 import seedu.address.model.employee.UniqueEmployeeList;
 import seedu.address.model.employee.exceptions.DuplicateEmployeeException;
 import seedu.address.model.project.CompletionStatus;
@@ -15,6 +16,7 @@ import seedu.address.model.project.Deadline;
 import seedu.address.model.project.Name;
 import seedu.address.model.project.Priority;
 import seedu.address.model.project.Project;
+import seedu.address.model.task.Task;
 import seedu.address.model.task.TaskList;
 
 /**
@@ -23,6 +25,7 @@ import seedu.address.model.task.TaskList;
 
 public class JsonAdaptedProject {
     public static final String MISSING_FIELD_MESSAGE_FORMAT = "Project's %s field is missing!";
+    public static final String MESSAGE_NOT_ASSIGNED_EMPLOYEE = "Employee(s) assigned to task not found in project!";
     private final String name;
     private final List<JsonAdaptedEmployee> employees = new ArrayList<>();
     private final List<JsonAdaptedTask> tasks = new ArrayList<>();
@@ -89,7 +92,13 @@ public class JsonAdaptedProject {
         final TaskList taskList = new TaskList();
         try {
             for (JsonAdaptedTask task : tasks) {
-                taskList.add(task.toModelType());
+                Task modeledTask = task.toModelType();
+                for(Employee assignedEmployee : modeledTask.getEmployee()) {
+                    if(!employeeList.strictlyContains(assignedEmployee)) {
+                        throw new IllegalValueException(MESSAGE_NOT_ASSIGNED_EMPLOYEE);
+                    }
+                }
+                taskList.add(modeledTask);
             }
         } catch (DuplicateEmployeeException e) {
             throw new IllegalValueException(e.getMessage());

--- a/src/main/java/seedu/address/storage/JsonAdaptedProject.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedProject.java
@@ -93,8 +93,8 @@ public class JsonAdaptedProject {
         try {
             for (JsonAdaptedTask task : tasks) {
                 Task modeledTask = task.toModelType();
-                for(Employee assignedEmployee : modeledTask.getEmployee()) {
-                    if(!employeeList.strictlyContains(assignedEmployee)) {
+                for (Employee assignedEmployee : modeledTask.getEmployee()) {
+                    if (!employeeList.strictlyContains(assignedEmployee)) {
                         throw new IllegalValueException(MESSAGE_NOT_ASSIGNED_EMPLOYEE);
                     }
                 }

--- a/src/main/java/seedu/address/storage/JsonSerializableTaskHub.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableTaskHub.java
@@ -22,6 +22,7 @@ class JsonSerializableTaskHub {
 
     public static final String MESSAGE_DUPLICATE_EMPLOYEE = "Employees list contains duplicate employee(s).";
     public static final String MESSAGE_DUPLICATE_PROJECT = "Projects list contains duplicate project(s).";
+    public static final String MESSAGE_NONEXISTENT_EMPLOYEE = "Employee(s) in project does not exist.";
 
     private final List<JsonAdaptedEmployee> employees = new ArrayList<>();
     private final List<JsonAdaptedProject> projects = new ArrayList<>();
@@ -64,6 +65,11 @@ class JsonSerializableTaskHub {
             Project project = jsonAdaptedProject.toModelType();
             if (taskHub.hasProject(project)) {
                 throw new IllegalValueException(MESSAGE_DUPLICATE_PROJECT);
+            }
+            for(Employee maybeEmployee : project.getEmployees()) {
+                if(!taskHub.strictlyHasEmployee(maybeEmployee)) {
+                    throw new IllegalValueException(MESSAGE_NONEXISTENT_EMPLOYEE);
+                }
             }
             taskHub.addProject(project);
         }

--- a/src/main/java/seedu/address/storage/JsonSerializableTaskHub.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableTaskHub.java
@@ -66,8 +66,8 @@ class JsonSerializableTaskHub {
             if (taskHub.hasProject(project)) {
                 throw new IllegalValueException(MESSAGE_DUPLICATE_PROJECT);
             }
-            for(Employee maybeEmployee : project.getEmployees()) {
-                if(!taskHub.strictlyHasEmployee(maybeEmployee)) {
+            for (Employee maybeEmployee : project.getEmployees()) {
+                if (!taskHub.strictlyHasEmployee(maybeEmployee)) {
                     throw new IllegalValueException(MESSAGE_NONEXISTENT_EMPLOYEE);
                 }
             }

--- a/src/test/java/seedu/address/logic/commands/AddProjectCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddProjectCommandTest.java
@@ -7,8 +7,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.AddProjectCommand.MESSAGE_DUPLICATE_PROJECT;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalEmployees.ALICE;
-import static seedu.address.testutil.TypicalProjects.ALPHA_FACTORY;
-import static seedu.address.testutil.TypicalProjects.BETA_FACTORY;
+import static seedu.address.testutil.TypicalProjects.alphaFactory;
+import static seedu.address.testutil.TypicalProjects.betaFactory;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -62,14 +62,14 @@ public class AddProjectCommandTest {
 
     @Test
     public void equals() {
-        AddProjectCommand addAlphaCommand = new AddProjectCommand(ALPHA_FACTORY(), new ArrayList<>());
-        AddProjectCommand addBetaCommand = new AddProjectCommand(BETA_FACTORY(), new ArrayList<>());
+        AddProjectCommand addAlphaCommand = new AddProjectCommand(alphaFactory(), new ArrayList<>());
+        AddProjectCommand addBetaCommand = new AddProjectCommand(betaFactory(), new ArrayList<>());
 
         // same object -> returns true
         assertTrue(addAlphaCommand.equals(addAlphaCommand));
 
         // same values -> returns true
-        AddProjectCommand addAlphaCommandCopy = new AddProjectCommand(ALPHA_FACTORY(), new ArrayList<>());
+        AddProjectCommand addAlphaCommandCopy = new AddProjectCommand(alphaFactory(), new ArrayList<>());
         assertTrue(addAlphaCommand.equals(addAlphaCommandCopy));
 
         // different types -> returns false
@@ -84,8 +84,8 @@ public class AddProjectCommandTest {
 
     @Test
     public void toStringMethod() {
-        AddProjectCommand addProjectCommand = new AddProjectCommand(ALPHA_FACTORY(), new ArrayList<>());
-        String expected = AddProjectCommand.class.getCanonicalName() + "{toAdd=" + ALPHA_FACTORY() + "}";
+        AddProjectCommand addProjectCommand = new AddProjectCommand(alphaFactory(), new ArrayList<>());
+        String expected = AddProjectCommand.class.getCanonicalName() + "{toAdd=" + alphaFactory() + "}";
         assertEquals(expected, addProjectCommand.toString());
     }
 

--- a/src/test/java/seedu/address/logic/commands/AddProjectCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddProjectCommandTest.java
@@ -7,8 +7,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.AddProjectCommand.MESSAGE_DUPLICATE_PROJECT;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalEmployees.ALICE;
-import static seedu.address.testutil.TypicalProjects.ALPHA;
-import static seedu.address.testutil.TypicalProjects.BETA;
+import static seedu.address.testutil.TypicalProjects.ALPHA_FACTORY;
+import static seedu.address.testutil.TypicalProjects.BETA_FACTORY;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -62,14 +62,14 @@ public class AddProjectCommandTest {
 
     @Test
     public void equals() {
-        AddProjectCommand addAlphaCommand = new AddProjectCommand(ALPHA, new ArrayList<>());
-        AddProjectCommand addBetaCommand = new AddProjectCommand(BETA, new ArrayList<>());
+        AddProjectCommand addAlphaCommand = new AddProjectCommand(ALPHA_FACTORY(), new ArrayList<>());
+        AddProjectCommand addBetaCommand = new AddProjectCommand(BETA_FACTORY(), new ArrayList<>());
 
         // same object -> returns true
         assertTrue(addAlphaCommand.equals(addAlphaCommand));
 
         // same values -> returns true
-        AddProjectCommand addAlphaCommandCopy = new AddProjectCommand(ALPHA, new ArrayList<>());
+        AddProjectCommand addAlphaCommandCopy = new AddProjectCommand(ALPHA_FACTORY(), new ArrayList<>());
         assertTrue(addAlphaCommand.equals(addAlphaCommandCopy));
 
         // different types -> returns false
@@ -84,8 +84,8 @@ public class AddProjectCommandTest {
 
     @Test
     public void toStringMethod() {
-        AddProjectCommand addProjectCommand = new AddProjectCommand(ALPHA, new ArrayList<>());
-        String expected = AddProjectCommand.class.getCanonicalName() + "{toAdd=" + ALPHA + "}";
+        AddProjectCommand addProjectCommand = new AddProjectCommand(ALPHA_FACTORY(), new ArrayList<>());
+        String expected = AddProjectCommand.class.getCanonicalName() + "{toAdd=" + ALPHA_FACTORY() + "}";
         assertEquals(expected, addProjectCommand.toString());
     }
 

--- a/src/test/java/seedu/address/logic/commands/AddTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddTaskCommandTest.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalEmployees.ALICE;
-import static seedu.address.testutil.TypicalProjects.ALPHA;
+import static seedu.address.testutil.TypicalProjects.ALPHA_FACTORY;
 import static seedu.address.testutil.TypicalTasks.ALPHA_TASK;
 import static seedu.address.testutil.TypicalTasks.BETA_TASK;
 
@@ -20,6 +20,7 @@ import seedu.address.model.task.Task;
 import seedu.address.testutil.ModelStubWithEmptyProjectList;
 import seedu.address.testutil.ModelStubWithEmptyProjectListAndEmptyEmployeeList;
 import seedu.address.testutil.ModelStubWithProjectAndEmployee;
+import seedu.address.testutil.ProjectBuilder;
 import seedu.address.testutil.TaskBuilder;
 public class AddTaskCommandTest {
     @Test
@@ -29,7 +30,7 @@ public class AddTaskCommandTest {
 
     @Test
     public void execute_taskWithoutAssigneeAcceptedByModel_addSuccessful() throws Exception {
-        ModelStubWithProjectAndEmployee modelStub = new ModelStubWithProjectAndEmployee(ALPHA, ALICE);
+        ModelStubWithProjectAndEmployee modelStub = new ModelStubWithProjectAndEmployee(ALPHA_FACTORY(), ALICE);
         Task validTask = new TaskBuilder().build();
         Index index = ParserUtil.parseIndex("1");
         CommandResult commandResult = new AddTaskCommand(validTask,
@@ -40,7 +41,7 @@ public class AddTaskCommandTest {
     }
     @Test
     public void execute_taskWithAssigneeAcceptedByModel_addSuccessful() throws Exception {
-        ModelStubWithProjectAndEmployee modelStub = new ModelStubWithProjectAndEmployee(ALPHA, ALICE);
+        ModelStubWithProjectAndEmployee modelStub = new ModelStubWithProjectAndEmployee(ALPHA_FACTORY(), ALICE);
         Task validTask = new TaskBuilder().build();
         Index projectIndex = ParserUtil.parseIndex("1");
         Index employeeIndex = ParserUtil.parseIndex("1");
@@ -54,7 +55,7 @@ public class AddTaskCommandTest {
 
     @Test
     public void execute_addTaskToInvalidProjectIndex_throwsCommandException() throws Exception {
-        ModelStubWithProjectAndEmployee modelStub = new ModelStubWithProjectAndEmployee(ALPHA, ALICE);
+        ModelStubWithProjectAndEmployee modelStub = new ModelStubWithProjectAndEmployee(ALPHA_FACTORY(), ALICE);
         Task validTask = new TaskBuilder().build();
         Index index = ParserUtil.parseIndex("2");
         AddTaskCommand addTaskCommand = new AddTaskCommand(validTask,
@@ -64,7 +65,8 @@ public class AddTaskCommandTest {
     }
     @Test
     public void execute_addTaskWithInvalidEmployeeIndex_throwsCommandException() throws Exception {
-        ModelStubWithProjectAndEmployee modelStub = new ModelStubWithProjectAndEmployee(ALPHA, ALICE);
+        ModelStubWithProjectAndEmployee modelStub =
+                new ModelStubWithProjectAndEmployee(new ProjectBuilder().withTasks(ALPHA_TASK).build(), ALICE);
         Task validTask = new TaskBuilder().build();
         Index projectIndex = ParserUtil.parseIndex("1");
         Index employeeIndex = ParserUtil.parseIndex("5");

--- a/src/test/java/seedu/address/logic/commands/AddTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddTaskCommandTest.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalEmployees.ALICE;
-import static seedu.address.testutil.TypicalProjects.ALPHA_FACTORY;
+import static seedu.address.testutil.TypicalProjects.alphaFactory;
 import static seedu.address.testutil.TypicalTasks.ALPHA_TASK;
 import static seedu.address.testutil.TypicalTasks.BETA_TASK;
 
@@ -30,7 +30,7 @@ public class AddTaskCommandTest {
 
     @Test
     public void execute_taskWithoutAssigneeAcceptedByModel_addSuccessful() throws Exception {
-        ModelStubWithProjectAndEmployee modelStub = new ModelStubWithProjectAndEmployee(ALPHA_FACTORY(), ALICE);
+        ModelStubWithProjectAndEmployee modelStub = new ModelStubWithProjectAndEmployee(alphaFactory(), ALICE);
         Task validTask = new TaskBuilder().build();
         Index index = ParserUtil.parseIndex("1");
         CommandResult commandResult = new AddTaskCommand(validTask,
@@ -41,7 +41,7 @@ public class AddTaskCommandTest {
     }
     @Test
     public void execute_taskWithAssigneeAcceptedByModel_addSuccessful() throws Exception {
-        ModelStubWithProjectAndEmployee modelStub = new ModelStubWithProjectAndEmployee(ALPHA_FACTORY(), ALICE);
+        ModelStubWithProjectAndEmployee modelStub = new ModelStubWithProjectAndEmployee(alphaFactory(), ALICE);
         Task validTask = new TaskBuilder().build();
         Index projectIndex = ParserUtil.parseIndex("1");
         Index employeeIndex = ParserUtil.parseIndex("1");
@@ -55,7 +55,7 @@ public class AddTaskCommandTest {
 
     @Test
     public void execute_addTaskToInvalidProjectIndex_throwsCommandException() throws Exception {
-        ModelStubWithProjectAndEmployee modelStub = new ModelStubWithProjectAndEmployee(ALPHA_FACTORY(), ALICE);
+        ModelStubWithProjectAndEmployee modelStub = new ModelStubWithProjectAndEmployee(alphaFactory(), ALICE);
         Task validTask = new TaskBuilder().build();
         Index index = ParserUtil.parseIndex("2");
         AddTaskCommand addTaskCommand = new AddTaskCommand(validTask,

--- a/src/test/java/seedu/address/logic/commands/AssignProjectCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AssignProjectCommandTest.java
@@ -5,7 +5,7 @@ import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalEmployees.ALICE;
 import static seedu.address.testutil.TypicalEmployees.BENSON;
 import static seedu.address.testutil.TypicalEmployees.getTypicalTaskHub;
-import static seedu.address.testutil.TypicalProjects.ALPHA_FACTORY;
+import static seedu.address.testutil.TypicalProjects.alphaFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -37,7 +37,9 @@ public class AssignProjectCommandTest {
     public void execute_validInputs_success() {
 
         Model expectedModel = new ModelManager(getTypicalTaskHub(), new UserPrefs());
-        expectedModel.setProject(ALPHA_FACTORY(), new ProjectBuilder(ALPHA_FACTORY()).withEmployees(ALICE, BENSON).build());
+        expectedModel.setProject(alphaFactory(), new ProjectBuilder(alphaFactory())
+                                                                    .withEmployees(ALICE, BENSON)
+                                                                    .build());
         AssignProjectCommand assignProjectCommand =
                 new AssignProjectCommand(Index.fromOneBased(1),
                         new ArrayList<>(Arrays.asList(Index.fromOneBased(2))));

--- a/src/test/java/seedu/address/logic/commands/AssignProjectCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AssignProjectCommandTest.java
@@ -5,7 +5,7 @@ import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalEmployees.ALICE;
 import static seedu.address.testutil.TypicalEmployees.BENSON;
 import static seedu.address.testutil.TypicalEmployees.getTypicalTaskHub;
-import static seedu.address.testutil.TypicalProjects.ALPHA;
+import static seedu.address.testutil.TypicalProjects.ALPHA_FACTORY;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -37,7 +37,7 @@ public class AssignProjectCommandTest {
     public void execute_validInputs_success() {
 
         Model expectedModel = new ModelManager(getTypicalTaskHub(), new UserPrefs());
-        expectedModel.setProject(ALPHA, new ProjectBuilder(ALPHA).withEmployees(ALICE, BENSON).build());
+        expectedModel.setProject(ALPHA_FACTORY(), new ProjectBuilder(ALPHA_FACTORY()).withEmployees(ALICE, BENSON).build());
         AssignProjectCommand assignProjectCommand =
                 new AssignProjectCommand(Index.fromOneBased(1),
                         new ArrayList<>(Arrays.asList(Index.fromOneBased(2))));

--- a/src/test/java/seedu/address/logic/commands/DeleteTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteTaskCommandTest.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalEmployees.ALICE;
-import static seedu.address.testutil.TypicalProjects.ALPHA_FACTORY;
+import static seedu.address.testutil.TypicalProjects.alphaFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -31,14 +31,14 @@ public class DeleteTaskCommandTest {
     @Test
     public void execute_deleteTaskOne_successful() throws Exception {
         // ALPHA contains ALPHA_TASK
-        ModelStubWithProjectAndEmployee modelStub = new ModelStubWithProjectAndEmployee(ALPHA_FACTORY(), ALICE);
+        ModelStubWithProjectAndEmployee modelStub = new ModelStubWithProjectAndEmployee(alphaFactory(), ALICE);
         Index projectIndex = ParserUtil.parseIndex("1");
         Index taskIndex = ParserUtil.parseIndex("1");
         List<Index> taskIndexes = new ArrayList<>();
         taskIndexes.add(taskIndex);
         CommandResult commandResult = new DeleteTaskCommand(projectIndex, taskIndexes).execute(modelStub);
         assertEquals(String.format(DeleteTaskCommand.MESSAGE_TASKS_DELETED_SUCCESSFULLY,
-                                   taskIndexes.size(), ALPHA_FACTORY().getName()),
+                                   taskIndexes.size(), alphaFactory().getName()),
                     commandResult.getFeedbackToUser());
     }
     @Test
@@ -57,7 +57,7 @@ public class DeleteTaskCommandTest {
 
     @Test
     public void execute_deleteTaskInvalidProjectIndex_throwsCommandException() throws Exception {
-        ModelStubWithProjectAndEmployee modelStub = new ModelStubWithProjectAndEmployee(ALPHA_FACTORY(), ALICE);
+        ModelStubWithProjectAndEmployee modelStub = new ModelStubWithProjectAndEmployee(alphaFactory(), ALICE);
         Index projectIndex = ParserUtil.parseIndex("50");
         Index taskIndex = ParserUtil.parseIndex("1");
         List<Index> taskIndexes = new ArrayList<>();
@@ -70,7 +70,7 @@ public class DeleteTaskCommandTest {
 
     @Test
     public void execute_deleteTaskInvalidTaskIndex_throwsCommandException() throws Exception {
-        ModelStubWithProjectAndEmployee modelStub = new ModelStubWithProjectAndEmployee(ALPHA_FACTORY(), ALICE);
+        ModelStubWithProjectAndEmployee modelStub = new ModelStubWithProjectAndEmployee(alphaFactory(), ALICE);
         Index projectIndex = ParserUtil.parseIndex("1");
         Index taskIndex = ParserUtil.parseIndex("50");
         List<Index> taskIndexes = new ArrayList<>();

--- a/src/test/java/seedu/address/logic/commands/DeleteTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteTaskCommandTest.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalEmployees.ALICE;
-import static seedu.address.testutil.TypicalProjects.ALPHA;
+import static seedu.address.testutil.TypicalProjects.ALPHA_FACTORY;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -31,14 +31,14 @@ public class DeleteTaskCommandTest {
     @Test
     public void execute_deleteTaskOne_successful() throws Exception {
         // ALPHA contains ALPHA_TASK
-        ModelStubWithProjectAndEmployee modelStub = new ModelStubWithProjectAndEmployee(ALPHA, ALICE);
+        ModelStubWithProjectAndEmployee modelStub = new ModelStubWithProjectAndEmployee(ALPHA_FACTORY(), ALICE);
         Index projectIndex = ParserUtil.parseIndex("1");
         Index taskIndex = ParserUtil.parseIndex("1");
         List<Index> taskIndexes = new ArrayList<>();
         taskIndexes.add(taskIndex);
         CommandResult commandResult = new DeleteTaskCommand(projectIndex, taskIndexes).execute(modelStub);
         assertEquals(String.format(DeleteTaskCommand.MESSAGE_TASKS_DELETED_SUCCESSFULLY,
-                                   taskIndexes.size(), ALPHA.getName()),
+                                   taskIndexes.size(), ALPHA_FACTORY().getName()),
                     commandResult.getFeedbackToUser());
     }
     @Test
@@ -57,7 +57,7 @@ public class DeleteTaskCommandTest {
 
     @Test
     public void execute_deleteTaskInvalidProjectIndex_throwsCommandException() throws Exception {
-        ModelStubWithProjectAndEmployee modelStub = new ModelStubWithProjectAndEmployee(ALPHA, ALICE);
+        ModelStubWithProjectAndEmployee modelStub = new ModelStubWithProjectAndEmployee(ALPHA_FACTORY(), ALICE);
         Index projectIndex = ParserUtil.parseIndex("50");
         Index taskIndex = ParserUtil.parseIndex("1");
         List<Index> taskIndexes = new ArrayList<>();
@@ -70,7 +70,7 @@ public class DeleteTaskCommandTest {
 
     @Test
     public void execute_deleteTaskInvalidTaskIndex_throwsCommandException() throws Exception {
-        ModelStubWithProjectAndEmployee modelStub = new ModelStubWithProjectAndEmployee(ALPHA, ALICE);
+        ModelStubWithProjectAndEmployee modelStub = new ModelStubWithProjectAndEmployee(ALPHA_FACTORY(), ALICE);
         Index projectIndex = ParserUtil.parseIndex("1");
         Index taskIndex = ParserUtil.parseIndex("50");
         List<Index> taskIndexes = new ArrayList<>();

--- a/src/test/java/seedu/address/logic/commands/EditEmployeeCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditEmployeeCommandTest.java
@@ -11,6 +11,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showEmployeeAtIndex;
+import static seedu.address.testutil.TypicalEmployees.getTypicalEmployees;
 import static seedu.address.testutil.TypicalEmployees.getTypicalTaskHub;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_EMPLOYEE;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_EMPLOYEE;

--- a/src/test/java/seedu/address/logic/commands/EditEmployeeCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditEmployeeCommandTest.java
@@ -11,7 +11,6 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showEmployeeAtIndex;
-import static seedu.address.testutil.TypicalEmployees.getTypicalEmployees;
 import static seedu.address.testutil.TypicalEmployees.getTypicalTaskHub;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_EMPLOYEE;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_EMPLOYEE;

--- a/src/test/java/seedu/address/logic/commands/FindProjectCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindProjectCommandTest.java
@@ -5,9 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.Messages.MESSAGE_PROJECTS_LISTED_OVERVIEW;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.testutil.TypicalProjects.BETA_FACTORY;
-import static seedu.address.testutil.TypicalProjects.DELTA_FACTORY;
-import static seedu.address.testutil.TypicalProjects.GAMMA_FACTORY;
+import static seedu.address.testutil.TypicalProjects.betaFactory;
+import static seedu.address.testutil.TypicalProjects.deltaFactory;
+import static seedu.address.testutil.TypicalProjects.gammaFactory;
 import static seedu.address.testutil.TypicalProjects.getTypicalTaskHub;
 
 import java.util.Arrays;
@@ -82,7 +82,7 @@ public class FindProjectCommandTest {
         expectedModel.updateFilteredEmployeeList(employeePredicate);
 
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Arrays.asList(BETA_FACTORY(), DELTA_FACTORY(), GAMMA_FACTORY()), model.getFilteredProjectList());
+        assertEquals(Arrays.asList(betaFactory(), deltaFactory(), gammaFactory()), model.getFilteredProjectList());
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/FindProjectCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindProjectCommandTest.java
@@ -5,9 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.Messages.MESSAGE_PROJECTS_LISTED_OVERVIEW;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.testutil.TypicalProjects.BETA;
-import static seedu.address.testutil.TypicalProjects.DELTA;
-import static seedu.address.testutil.TypicalProjects.GAMMA;
+import static seedu.address.testutil.TypicalProjects.BETA_FACTORY;
+import static seedu.address.testutil.TypicalProjects.DELTA_FACTORY;
+import static seedu.address.testutil.TypicalProjects.GAMMA_FACTORY;
 import static seedu.address.testutil.TypicalProjects.getTypicalTaskHub;
 
 import java.util.Arrays;
@@ -82,7 +82,7 @@ public class FindProjectCommandTest {
         expectedModel.updateFilteredEmployeeList(employeePredicate);
 
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Arrays.asList(BETA, DELTA, GAMMA), model.getFilteredProjectList());
+        assertEquals(Arrays.asList(BETA_FACTORY(), DELTA_FACTORY(), GAMMA_FACTORY()), model.getFilteredProjectList());
     }
 
     @Test

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -7,7 +7,7 @@ import static seedu.address.model.Model.PREDICATE_SHOW_ALL_EMPLOYEES;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalEmployees.ALICE;
 import static seedu.address.testutil.TypicalEmployees.BENSON;
-import static seedu.address.testutil.TypicalProjects.ALPHA;
+import static seedu.address.testutil.TypicalProjects.ALPHA_FACTORY;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -90,7 +90,7 @@ public class ModelManagerTest {
 
     @Test
     public void hasProject_projectNotInTaskHub_returnsFalse() {
-        assertFalse(modelManager.hasProject(ALPHA));
+        assertFalse(modelManager.hasProject(ALPHA_FACTORY()));
     }
 
     @Test
@@ -101,8 +101,8 @@ public class ModelManagerTest {
 
     @Test
     public void hasProject_projectInTaskHub_returnsTrue() {
-        modelManager.addProject(ALPHA);
-        assertTrue(modelManager.hasProject(ALPHA));
+        modelManager.addProject(ALPHA_FACTORY());
+        assertTrue(modelManager.hasProject(ALPHA_FACTORY()));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -7,7 +7,7 @@ import static seedu.address.model.Model.PREDICATE_SHOW_ALL_EMPLOYEES;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalEmployees.ALICE;
 import static seedu.address.testutil.TypicalEmployees.BENSON;
-import static seedu.address.testutil.TypicalProjects.ALPHA_FACTORY;
+import static seedu.address.testutil.TypicalProjects.alphaFactory;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -90,7 +90,7 @@ public class ModelManagerTest {
 
     @Test
     public void hasProject_projectNotInTaskHub_returnsFalse() {
-        assertFalse(modelManager.hasProject(ALPHA_FACTORY()));
+        assertFalse(modelManager.hasProject(alphaFactory()));
     }
 
     @Test
@@ -101,8 +101,8 @@ public class ModelManagerTest {
 
     @Test
     public void hasProject_projectInTaskHub_returnsTrue() {
-        modelManager.addProject(ALPHA_FACTORY());
-        assertTrue(modelManager.hasProject(ALPHA_FACTORY()));
+        modelManager.addProject(alphaFactory());
+        assertTrue(modelManager.hasProject(alphaFactory()));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/TaskHubTest.java
+++ b/src/test/java/seedu/address/model/TaskHubTest.java
@@ -8,7 +8,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalEmployees.ALICE;
 import static seedu.address.testutil.TypicalEmployees.getTypicalTaskHub;
-import static seedu.address.testutil.TypicalProjects.ALPHA;
+import static seedu.address.testutil.TypicalProjects.ALPHA_FACTORY;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -76,13 +76,13 @@ public class TaskHubTest {
 
     @Test
     public void hasProject_projectNotInTaskHub_returnFalse() {
-        assertFalse(taskHub.hasProject(ALPHA));
+        assertFalse(taskHub.hasProject(ALPHA_FACTORY()));
     }
 
     @Test
     public void hasProject_projectInTaskHub_returnsTrue() {
-        taskHub.addProject(ALPHA);
-        assertTrue(taskHub.hasProject(ALPHA));
+        taskHub.addProject(ALPHA_FACTORY());
+        assertTrue(taskHub.hasProject(ALPHA_FACTORY()));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/TaskHubTest.java
+++ b/src/test/java/seedu/address/model/TaskHubTest.java
@@ -8,7 +8,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalEmployees.ALICE;
 import static seedu.address.testutil.TypicalEmployees.getTypicalTaskHub;
-import static seedu.address.testutil.TypicalProjects.ALPHA_FACTORY;
+import static seedu.address.testutil.TypicalProjects.alphaFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -76,13 +76,13 @@ public class TaskHubTest {
 
     @Test
     public void hasProject_projectNotInTaskHub_returnFalse() {
-        assertFalse(taskHub.hasProject(ALPHA_FACTORY()));
+        assertFalse(taskHub.hasProject(alphaFactory()));
     }
 
     @Test
     public void hasProject_projectInTaskHub_returnsTrue() {
-        taskHub.addProject(ALPHA_FACTORY());
-        assertTrue(taskHub.hasProject(ALPHA_FACTORY()));
+        taskHub.addProject(alphaFactory());
+        assertTrue(taskHub.hasProject(alphaFactory()));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/project/UniqueProjectListTest.java
+++ b/src/test/java/seedu/address/model/project/UniqueProjectListTest.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalEmployees.BOB;
-import static seedu.address.testutil.TypicalProjects.ALPHA;
+import static seedu.address.testutil.TypicalProjects.ALPHA_FACTORY;
 
 import org.junit.jupiter.api.Test;
 
@@ -23,25 +23,25 @@ public class UniqueProjectListTest {
 
     @Test
     public void contains_projectNotInList_returnsFalse() {
-        assertFalse(uniqueProjectList.contains(ALPHA));
+        assertFalse(uniqueProjectList.contains(ALPHA_FACTORY()));
     }
 
     @Test
     public void contains_projectInList_returnsTrue() {
-        uniqueProjectList.add(ALPHA);
-        assertTrue(uniqueProjectList.contains(ALPHA));
+        uniqueProjectList.add(ALPHA_FACTORY());
+        assertTrue(uniqueProjectList.contains(ALPHA_FACTORY()));
     }
 
     @Test
     public void contains_projectWithSameIdentityFieldsInList_returnsTrue() {
-        uniqueProjectList.add(ALPHA);
-        Project editedAlpha = new ProjectBuilder(ALPHA).withEmployees(BOB).build();
+        uniqueProjectList.add(ALPHA_FACTORY());
+        Project editedAlpha = new ProjectBuilder(ALPHA_FACTORY()).withEmployees(BOB).build();
         assertTrue(uniqueProjectList.contains(editedAlpha));
     }
 
     @Test
     public void updateProject_success() {
-        uniqueProjectList.add(ALPHA);
+        uniqueProjectList.add(ALPHA_FACTORY());
         UniqueProjectList otherList = new UniqueProjectList();
         otherList.setProjects(uniqueProjectList);
 
@@ -55,8 +55,8 @@ public class UniqueProjectListTest {
 
     @Test
     public void add_duplicateProject_throwsDuplicateProjectException() {
-        uniqueProjectList.add(ALPHA);
-        assertThrows(DuplicateProjectException.class, () -> uniqueProjectList.add(ALPHA));
+        uniqueProjectList.add(ALPHA_FACTORY());
+        assertThrows(DuplicateProjectException.class, () -> uniqueProjectList.add(ALPHA_FACTORY()));
     }
 
     @Test
@@ -66,12 +66,12 @@ public class UniqueProjectListTest {
 
     @Test
     public void remove_projectDoesNotExist_throwsProjectNotFoundException() {
-        assertThrows(ProjectNotFoundException.class, () -> uniqueProjectList.remove(ALPHA));
+        assertThrows(ProjectNotFoundException.class, () -> uniqueProjectList.remove(ALPHA_FACTORY()));
     }
     @Test
     public void remove_existingProject_removesProject() {
-        uniqueProjectList.add(ALPHA);
-        uniqueProjectList.remove(ALPHA);
+        uniqueProjectList.add(ALPHA_FACTORY());
+        uniqueProjectList.remove(ALPHA_FACTORY());
         UniqueProjectList expectedUniqueProjectList = new UniqueProjectList();
         assertEquals(expectedUniqueProjectList, uniqueProjectList);
     }

--- a/src/test/java/seedu/address/model/project/UniqueProjectListTest.java
+++ b/src/test/java/seedu/address/model/project/UniqueProjectListTest.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalEmployees.BOB;
-import static seedu.address.testutil.TypicalProjects.ALPHA_FACTORY;
+import static seedu.address.testutil.TypicalProjects.alphaFactory;
 
 import org.junit.jupiter.api.Test;
 
@@ -23,25 +23,25 @@ public class UniqueProjectListTest {
 
     @Test
     public void contains_projectNotInList_returnsFalse() {
-        assertFalse(uniqueProjectList.contains(ALPHA_FACTORY()));
+        assertFalse(uniqueProjectList.contains(alphaFactory()));
     }
 
     @Test
     public void contains_projectInList_returnsTrue() {
-        uniqueProjectList.add(ALPHA_FACTORY());
-        assertTrue(uniqueProjectList.contains(ALPHA_FACTORY()));
+        uniqueProjectList.add(alphaFactory());
+        assertTrue(uniqueProjectList.contains(alphaFactory()));
     }
 
     @Test
     public void contains_projectWithSameIdentityFieldsInList_returnsTrue() {
-        uniqueProjectList.add(ALPHA_FACTORY());
-        Project editedAlpha = new ProjectBuilder(ALPHA_FACTORY()).withEmployees(BOB).build();
+        uniqueProjectList.add(alphaFactory());
+        Project editedAlpha = new ProjectBuilder(alphaFactory()).withEmployees(BOB).build();
         assertTrue(uniqueProjectList.contains(editedAlpha));
     }
 
     @Test
     public void updateProject_success() {
-        uniqueProjectList.add(ALPHA_FACTORY());
+        uniqueProjectList.add(alphaFactory());
         UniqueProjectList otherList = new UniqueProjectList();
         otherList.setProjects(uniqueProjectList);
 
@@ -55,8 +55,8 @@ public class UniqueProjectListTest {
 
     @Test
     public void add_duplicateProject_throwsDuplicateProjectException() {
-        uniqueProjectList.add(ALPHA_FACTORY());
-        assertThrows(DuplicateProjectException.class, () -> uniqueProjectList.add(ALPHA_FACTORY()));
+        uniqueProjectList.add(alphaFactory());
+        assertThrows(DuplicateProjectException.class, () -> uniqueProjectList.add(alphaFactory()));
     }
 
     @Test
@@ -66,12 +66,12 @@ public class UniqueProjectListTest {
 
     @Test
     public void remove_projectDoesNotExist_throwsProjectNotFoundException() {
-        assertThrows(ProjectNotFoundException.class, () -> uniqueProjectList.remove(ALPHA_FACTORY()));
+        assertThrows(ProjectNotFoundException.class, () -> uniqueProjectList.remove(alphaFactory()));
     }
     @Test
     public void remove_existingProject_removesProject() {
-        uniqueProjectList.add(ALPHA_FACTORY());
-        uniqueProjectList.remove(ALPHA_FACTORY());
+        uniqueProjectList.add(alphaFactory());
+        uniqueProjectList.remove(alphaFactory());
         UniqueProjectList expectedUniqueProjectList = new UniqueProjectList();
         assertEquals(expectedUniqueProjectList, uniqueProjectList);
     }

--- a/src/test/java/seedu/address/storage/JsonAdaptedProjectTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedProjectTest.java
@@ -3,7 +3,7 @@ package seedu.address.storage;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.storage.JsonAdaptedProject.MISSING_FIELD_MESSAGE_FORMAT;
 import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalProjects.ALPHA_FACTORY;
+import static seedu.address.testutil.TypicalProjects.alphaFactory;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -21,23 +21,24 @@ public class JsonAdaptedProjectTest {
     public static final String INVALID_DEADLINE = "32/13/2024";
     public static final String INVALID_PRIORITY = "    ";
 
-    public static final String VALID_NAME = ALPHA_FACTORY().getName().toString();
-    public static final List<JsonAdaptedEmployee> VALID_EMPLOYEES = ALPHA_FACTORY().getEmployees().asUnmodifiableObservableList()
+    public static final String VALID_NAME = alphaFactory().getName().toString();
+    public static final List<JsonAdaptedEmployee> VALID_EMPLOYEES = alphaFactory().getEmployees()
+            .asUnmodifiableObservableList()
             .stream()
             .map(JsonAdaptedEmployee::new)
             .collect(Collectors.toList());
-    public static final List<JsonAdaptedTask> VALID_TASKS = ALPHA_FACTORY().getTasks().asUnmodifiableObservableList()
+    public static final List<JsonAdaptedTask> VALID_TASKS = alphaFactory().getTasks().asUnmodifiableObservableList()
             .stream()
             .map(JsonAdaptedTask::new)
             .collect(Collectors.toList());
-    public static final String VALID_DEADLINE = ALPHA_FACTORY().getDeadline().toString();
+    public static final String VALID_DEADLINE = alphaFactory().getDeadline().toString();
     public static final String VALID_PRIORITY = "normal";
-    public static final boolean VALID_COMPLETION_STATUS = ALPHA_FACTORY().getCompletionStatus().isCompleted;
+    public static final boolean VALID_COMPLETION_STATUS = alphaFactory().getCompletionStatus().isCompleted;
 
     @Test
     public void toModelType_validProjectDetails_returnsProject() throws Exception {
-        JsonAdaptedProject project = new JsonAdaptedProject(ALPHA_FACTORY());
-        assertEquals(ALPHA_FACTORY(), project.toModelType());
+        JsonAdaptedProject project = new JsonAdaptedProject(alphaFactory());
+        assertEquals(alphaFactory(), project.toModelType());
     }
 
     @Test

--- a/src/test/java/seedu/address/storage/JsonAdaptedProjectTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedProjectTest.java
@@ -3,7 +3,7 @@ package seedu.address.storage;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.storage.JsonAdaptedProject.MISSING_FIELD_MESSAGE_FORMAT;
 import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalProjects.ALPHA;
+import static seedu.address.testutil.TypicalProjects.ALPHA_FACTORY;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -21,23 +21,23 @@ public class JsonAdaptedProjectTest {
     public static final String INVALID_DEADLINE = "32/13/2024";
     public static final String INVALID_PRIORITY = "    ";
 
-    public static final String VALID_NAME = ALPHA.getName().toString();
-    public static final List<JsonAdaptedEmployee> VALID_EMPLOYEES = ALPHA.getEmployees().asUnmodifiableObservableList()
+    public static final String VALID_NAME = ALPHA_FACTORY().getName().toString();
+    public static final List<JsonAdaptedEmployee> VALID_EMPLOYEES = ALPHA_FACTORY().getEmployees().asUnmodifiableObservableList()
             .stream()
             .map(JsonAdaptedEmployee::new)
             .collect(Collectors.toList());
-    public static final List<JsonAdaptedTask> VALID_TASKS = ALPHA.getTasks().asUnmodifiableObservableList()
+    public static final List<JsonAdaptedTask> VALID_TASKS = ALPHA_FACTORY().getTasks().asUnmodifiableObservableList()
             .stream()
             .map(JsonAdaptedTask::new)
             .collect(Collectors.toList());
-    public static final String VALID_DEADLINE = ALPHA.getDeadline().toString();
+    public static final String VALID_DEADLINE = ALPHA_FACTORY().getDeadline().toString();
     public static final String VALID_PRIORITY = "normal";
-    public static final boolean VALID_COMPLETION_STATUS = ALPHA.getCompletionStatus().isCompleted;
+    public static final boolean VALID_COMPLETION_STATUS = ALPHA_FACTORY().getCompletionStatus().isCompleted;
 
     @Test
     public void toModelType_validProjectDetails_returnsProject() throws Exception {
-        JsonAdaptedProject project = new JsonAdaptedProject(ALPHA);
-        assertEquals(ALPHA, project.toModelType());
+        JsonAdaptedProject project = new JsonAdaptedProject(ALPHA_FACTORY());
+        assertEquals(ALPHA_FACTORY(), project.toModelType());
     }
 
     @Test

--- a/src/test/java/seedu/address/storage/JsonTaskHubStorageTest.java
+++ b/src/test/java/seedu/address/storage/JsonTaskHubStorageTest.java
@@ -7,7 +7,7 @@ import static seedu.address.testutil.TypicalEmployees.ALICE;
 import static seedu.address.testutil.TypicalEmployees.HOON;
 import static seedu.address.testutil.TypicalEmployees.IDA;
 import static seedu.address.testutil.TypicalEmployees.getTypicalTaskHub;
-import static seedu.address.testutil.TypicalProjects.ALPHA;
+import static seedu.address.testutil.TypicalProjects.ALPHA_FACTORY;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -76,9 +76,9 @@ public class JsonTaskHubStorageTest {
 
         // Modify data, overwrite exiting file, and read back
         original.addEmployee(HOON);
-        original.addProject(ALPHA);
+        original.addProject(ALPHA_FACTORY());
         original.removeEmployee(ALICE);
-        original.removeProject(ALPHA);
+        original.removeProject(ALPHA_FACTORY());
         jsonTaskHubStorage.saveTaskHub(original, filePath);
         readBack = jsonTaskHubStorage.readTaskHub(filePath).get();
         assertEquals(original, new TaskHub(readBack));

--- a/src/test/java/seedu/address/storage/JsonTaskHubStorageTest.java
+++ b/src/test/java/seedu/address/storage/JsonTaskHubStorageTest.java
@@ -7,7 +7,7 @@ import static seedu.address.testutil.TypicalEmployees.ALICE;
 import static seedu.address.testutil.TypicalEmployees.HOON;
 import static seedu.address.testutil.TypicalEmployees.IDA;
 import static seedu.address.testutil.TypicalEmployees.getTypicalTaskHub;
-import static seedu.address.testutil.TypicalProjects.ALPHA_FACTORY;
+import static seedu.address.testutil.TypicalProjects.alphaFactory;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -76,9 +76,9 @@ public class JsonTaskHubStorageTest {
 
         // Modify data, overwrite exiting file, and read back
         original.addEmployee(HOON);
-        original.addProject(ALPHA_FACTORY());
+        original.addProject(alphaFactory());
         original.removeEmployee(ALICE);
-        original.removeProject(ALPHA_FACTORY());
+        original.removeProject(alphaFactory());
         jsonTaskHubStorage.saveTaskHub(original, filePath);
         readBack = jsonTaskHubStorage.readTaskHub(filePath).get();
         assertEquals(original, new TaskHub(readBack));

--- a/src/test/java/seedu/address/storage/StorageManagerTest.java
+++ b/src/test/java/seedu/address/storage/StorageManagerTest.java
@@ -2,7 +2,9 @@ package seedu.address.storage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static seedu.address.testutil.TypicalEmployees.ALICE;
 import static seedu.address.testutil.TypicalEmployees.getTypicalTaskHub;
+import static seedu.address.testutil.TypicalProjects.ALPHA_FACTORY;
 
 import java.nio.file.Path;
 
@@ -55,6 +57,9 @@ public class StorageManagerTest {
          * More extensive testing of UserPref saving/reading is done in {@link JsonTaskHubStorageTest} class.
          */
         TaskHub original = getTypicalTaskHub();
+        if (!ALPHA_FACTORY().getEmployees().contains(ALICE)) {
+            ALPHA_FACTORY().addEmployee(ALICE);
+        }
         storageManager.saveTaskHub(original);
         ReadOnlyTaskHub retrieved = storageManager.readTaskHub().get();
         assertEquals(original, new TaskHub(retrieved));

--- a/src/test/java/seedu/address/storage/StorageManagerTest.java
+++ b/src/test/java/seedu/address/storage/StorageManagerTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static seedu.address.testutil.TypicalEmployees.ALICE;
 import static seedu.address.testutil.TypicalEmployees.getTypicalTaskHub;
-import static seedu.address.testutil.TypicalProjects.ALPHA_FACTORY;
+import static seedu.address.testutil.TypicalProjects.alphaFactory;
 
 import java.nio.file.Path;
 
@@ -57,8 +57,8 @@ public class StorageManagerTest {
          * More extensive testing of UserPref saving/reading is done in {@link JsonTaskHubStorageTest} class.
          */
         TaskHub original = getTypicalTaskHub();
-        if (!ALPHA_FACTORY().getEmployees().contains(ALICE)) {
-            ALPHA_FACTORY().addEmployee(ALICE);
+        if (!alphaFactory().getEmployees().contains(ALICE)) {
+            alphaFactory().addEmployee(ALICE);
         }
         storageManager.saveTaskHub(original);
         ReadOnlyTaskHub retrieved = storageManager.readTaskHub().get();

--- a/src/test/java/seedu/address/testutil/ProjectBuilder.java
+++ b/src/test/java/seedu/address/testutil/ProjectBuilder.java
@@ -38,7 +38,6 @@ public class ProjectBuilder {
         employeeList = new UniqueEmployeeList();
         employeeList.add(ALICE);
         taskList = new TaskList();
-        taskList.add(ALPHA_TASK);
         priority = new Priority(DEFAULT_PRIORITY);
         deadline = new Deadline(DEFAULT_DEADLINE);
         completionStatus = new CompletionStatus(DEFAULT_COMPLETION_STATUS);

--- a/src/test/java/seedu/address/testutil/ProjectBuilder.java
+++ b/src/test/java/seedu/address/testutil/ProjectBuilder.java
@@ -1,7 +1,6 @@
 package seedu.address.testutil;
 
 import static seedu.address.testutil.TypicalEmployees.ALICE;
-import static seedu.address.testutil.TypicalTasks.ALPHA_TASK;
 
 import seedu.address.model.employee.Employee;
 import seedu.address.model.employee.UniqueEmployeeList;

--- a/src/test/java/seedu/address/testutil/TaskBuilder.java
+++ b/src/test/java/seedu/address/testutil/TaskBuilder.java
@@ -17,7 +17,6 @@ public class TaskBuilder {
     public static final String DEFAULT_NAME = "ALPHA_TASK";
     public static final String DEFAULT_DEADLINE = "11-11-2023 2359";
     public static final boolean DEFAULT_COMPLETION_STATUS = false;
-    public static final List<Employee> DEFAULT_EMPLOYEE = new ArrayList<>();
 
     private String name;
     private LocalDateTime deadline;
@@ -35,7 +34,7 @@ public class TaskBuilder {
             System.out.print("This should not print");
         }
         isDone = DEFAULT_COMPLETION_STATUS;
-        employee = DEFAULT_EMPLOYEE;
+        employee = new ArrayList<>();
     }
 
     /**

--- a/src/test/java/seedu/address/testutil/TypicalProjects.java
+++ b/src/test/java/seedu/address/testutil/TypicalProjects.java
@@ -21,50 +21,75 @@ import seedu.address.model.project.Project;
  * A utility class containing a list of {@code Project} objects to be used in tests.
  */
 public class TypicalProjects {
-    public static Project ALPHA_FACTORY() {
+    private TypicalProjects() {} // prevents instantiation
+
+    /**
+     * Factory method for Project with name ALPHA.
+     */
+    public static Project alphaFactory() {
         return new ProjectBuilder().withTasks(ALPHA_TASK).withEmployees(ALICE).build();
     }
-    public static Project BETA_FACTORY() {
+
+    /**
+     * Factory method for Project with name BETA.
+     */
+    public static Project betaFactory() {
         return new ProjectBuilder().withName("Beta").withEmployees(BENSON).withTasks(ALPHA_TASK)
                 .withDeadline("10-12-2022").withCompletionStatus(false).build();
     }
-    public static Project DELTA_FACTORY() {
-        return  new ProjectBuilder().withName("Delta").withEmployees(DANIEL, FIONA)
+
+    /**
+     * Factory method for Project with name DELTA.
+     */
+    public static Project deltaFactory() {
+        return new ProjectBuilder().withName("Delta").withEmployees(DANIEL, FIONA)
                 .withTasks(ALPHA_TASK, BETA_TASK)
                 .withDeadline("24-11-2024").withCompletionStatus(true).build();
 
     }
     //Manually added
-    public static final Project GAMMA_FACTORY() {
+
+    /**
+     * Factory method for Project with name GAMMA.
+     */
+    public static Project gammaFactory() {
         return new ProjectBuilder().withName("Gamma").withEmployees(GEORGE)
                 .withTasks(ALPHA_TASK, BETA_TASK, CHARLIE_TASK)
                 .withDeadline("08-07-2023").build();
     }
 
-    private static Project HIGH_PRIORITY_PROJECT_FACTORY() {
-        return new  ProjectBuilder()
+    /**
+     * Factory method for Project with high Priority.
+     */
+    private static Project highPriorityProjectFactory() {
+        return new ProjectBuilder()
                 .withName("High Priority Project")
                 .withTasks(ALPHA_TASK, BETA_TASK, CHARLIE_TASK)
                 .withPriority("high")
                 .build();
     }
-    private static Project LOW_PRIORITY_PROJECT_FACTORY() {
-        return  new ProjectBuilder()
+
+    /**
+     * Factory method for Project with low Priority.
+     */
+    private static Project lowPriorityProjectFactory() {
+        return new ProjectBuilder()
                 .withName("Low Priority Project")
                 .withTasks(ALPHA_TASK, BETA_TASK, CHARLIE_TASK)
                 .withPriority("low")
                 .build();
     }
 
-    private static Project ASSIGNED_TASKS_PROJECT_FACTORY() {
+    /**
+     * Factory method for Project with assigned tasks.
+     */
+    private static Project assignedTasksProjectFactory() {
         return new ProjectBuilder()
                 .withName("Project with assigned task")
                 .withEmployees(ALICE)
                 .withTasks(ALPHA_TASK, DELTA_TASK)
                 .build();
     }
-
-    private TypicalProjects() {} // prevents instantiation
 
     /**
      * Returns an {@code TaskHub} with all the typical projects.
@@ -74,9 +99,9 @@ public class TypicalProjects {
     }
 
     public static List<Project> getTypicalProjects() {
-        return new ArrayList<>(Arrays.asList(ALPHA_FACTORY(), BETA_FACTORY(), DELTA_FACTORY(), GAMMA_FACTORY(),
-                HIGH_PRIORITY_PROJECT_FACTORY(), LOW_PRIORITY_PROJECT_FACTORY(),
-                ASSIGNED_TASKS_PROJECT_FACTORY()));
+        return new ArrayList<>(Arrays.asList(alphaFactory(), betaFactory(), deltaFactory(), gammaFactory(),
+                highPriorityProjectFactory(), lowPriorityProjectFactory(),
+                assignedTasksProjectFactory()));
     }
 
 

--- a/src/test/java/seedu/address/testutil/TypicalProjects.java
+++ b/src/test/java/seedu/address/testutil/TypicalProjects.java
@@ -1,7 +1,6 @@
 package seedu.address.testutil;
 
 import static seedu.address.testutil.TypicalEmployees.ALICE;
-import static seedu.address.testutil.TypicalEmployees.AMY;
 import static seedu.address.testutil.TypicalEmployees.BENSON;
 import static seedu.address.testutil.TypicalEmployees.DANIEL;
 import static seedu.address.testutil.TypicalEmployees.FIONA;

--- a/src/test/java/seedu/address/testutil/TypicalProjects.java
+++ b/src/test/java/seedu/address/testutil/TypicalProjects.java
@@ -1,5 +1,7 @@
 package seedu.address.testutil;
 
+import static seedu.address.testutil.TypicalEmployees.ALICE;
+import static seedu.address.testutil.TypicalEmployees.AMY;
 import static seedu.address.testutil.TypicalEmployees.BENSON;
 import static seedu.address.testutil.TypicalEmployees.DANIEL;
 import static seedu.address.testutil.TypicalEmployees.FIONA;
@@ -46,6 +48,7 @@ public class TypicalProjects {
 
     public static final Project ASSIGNED_TASKS_PROJECT = new ProjectBuilder()
             .withName("Project with assigned task")
+            .withEmployees(ALICE)
             .withTasks(ALPHA_TASK, DELTA_TASK)
             .build();
 

--- a/src/test/java/seedu/address/testutil/TypicalProjects.java
+++ b/src/test/java/seedu/address/testutil/TypicalProjects.java
@@ -21,35 +21,48 @@ import seedu.address.model.project.Project;
  * A utility class containing a list of {@code Project} objects to be used in tests.
  */
 public class TypicalProjects {
-    public static final Project ALPHA = new ProjectBuilder().withTasks(ALPHA_TASK).build();
-    public static final Project BETA = new ProjectBuilder().withName("Beta").withEmployees(BENSON).withTasks(ALPHA_TASK)
-            .withDeadline("10-12-2022").withCompletionStatus(false).build();
-    public static final Project DELTA = new ProjectBuilder().withName("Delta").withEmployees(DANIEL, FIONA)
-            .withTasks(ALPHA_TASK, BETA_TASK)
-            .withDeadline("24-11-2024").withCompletionStatus(true).build();
+    public static Project ALPHA_FACTORY() {
+        return new ProjectBuilder().withTasks(ALPHA_TASK).withEmployees(ALICE).build();
+    }
+    public static Project BETA_FACTORY() {
+        return new ProjectBuilder().withName("Beta").withEmployees(BENSON).withTasks(ALPHA_TASK)
+                .withDeadline("10-12-2022").withCompletionStatus(false).build();
+    }
+    public static Project DELTA_FACTORY() {
+        return  new ProjectBuilder().withName("Delta").withEmployees(DANIEL, FIONA)
+                .withTasks(ALPHA_TASK, BETA_TASK)
+                .withDeadline("24-11-2024").withCompletionStatus(true).build();
 
+    }
     //Manually added
-    public static final Project GAMMA = new ProjectBuilder().withName("Gamma").withEmployees(GEORGE)
-            .withTasks(ALPHA_TASK, BETA_TASK, CHARLIE_TASK)
-            .withDeadline("08-07-2023").build();
+    public static final Project GAMMA_FACTORY() {
+        return new ProjectBuilder().withName("Gamma").withEmployees(GEORGE)
+                .withTasks(ALPHA_TASK, BETA_TASK, CHARLIE_TASK)
+                .withDeadline("08-07-2023").build();
+    }
 
-    public static final Project HIGH_PRIORITY_PROJECT = new ProjectBuilder()
-            .withName("High Priority Project")
-            .withTasks(ALPHA_TASK, BETA_TASK, CHARLIE_TASK)
-            .withPriority("high")
-            .build();
+    private static Project HIGH_PRIORITY_PROJECT_FACTORY() {
+        return new  ProjectBuilder()
+                .withName("High Priority Project")
+                .withTasks(ALPHA_TASK, BETA_TASK, CHARLIE_TASK)
+                .withPriority("high")
+                .build();
+    }
+    private static Project LOW_PRIORITY_PROJECT_FACTORY() {
+        return  new ProjectBuilder()
+                .withName("Low Priority Project")
+                .withTasks(ALPHA_TASK, BETA_TASK, CHARLIE_TASK)
+                .withPriority("low")
+                .build();
+    }
 
-    public static final Project LOW_PRIORITY_PROJECT = new ProjectBuilder()
-            .withName("Low Priority Project")
-            .withTasks(ALPHA_TASK, BETA_TASK, CHARLIE_TASK)
-            .withPriority("low")
-            .build();
-
-    public static final Project ASSIGNED_TASKS_PROJECT = new ProjectBuilder()
-            .withName("Project with assigned task")
-            .withEmployees(ALICE)
-            .withTasks(ALPHA_TASK, DELTA_TASK)
-            .build();
+    private static Project ASSIGNED_TASKS_PROJECT_FACTORY() {
+        return new ProjectBuilder()
+                .withName("Project with assigned task")
+                .withEmployees(ALICE)
+                .withTasks(ALPHA_TASK, DELTA_TASK)
+                .build();
+    }
 
     private TypicalProjects() {} // prevents instantiation
 
@@ -61,8 +74,10 @@ public class TypicalProjects {
     }
 
     public static List<Project> getTypicalProjects() {
-        return new ArrayList<>(Arrays.asList(ALPHA, BETA, DELTA, GAMMA,
-                HIGH_PRIORITY_PROJECT, LOW_PRIORITY_PROJECT,
-                ASSIGNED_TASKS_PROJECT));
+        return new ArrayList<>(Arrays.asList(ALPHA_FACTORY(), BETA_FACTORY(), DELTA_FACTORY(), GAMMA_FACTORY(),
+                HIGH_PRIORITY_PROJECT_FACTORY(), LOW_PRIORITY_PROJECT_FACTORY(),
+                ASSIGNED_TASKS_PROJECT_FACTORY()));
     }
+
+
 }

--- a/src/test/java/seedu/address/testutil/TypicalTasks.java
+++ b/src/test/java/seedu/address/testutil/TypicalTasks.java
@@ -1,7 +1,7 @@
 package seedu.address.testutil;
 
 
-import static seedu.address.testutil.TypicalEmployees.AMY;
+import static seedu.address.testutil.TypicalEmployees.ALICE;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -19,7 +19,7 @@ import seedu.address.model.task.Task;
 public class TypicalTasks {
     public static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("dd-MM-yyyy HHmm");
     public static final LocalDateTime DEFAULT_DEADLINE = LocalDateTime.parse("11-11-2023 2359", FORMATTER);
-    public static final List<Employee> DEFAULT_EMPLOYEE = Collections.singletonList(AMY);
+    public static final List<Employee> DEFAULT_EMPLOYEE = Collections.singletonList(ALICE);
 
     public static final Task ALPHA_TASK = new TaskBuilder().build();
     public static final Task BETA_TASK = new TaskBuilder().withName("Beta")


### PR DESCRIPTION
Close #207 
After this PR, users cannot modify the stored .json file to create employees that are in a project but not in the employee list, and employees that are assigned to a task in a project but not in the project itself. Doing so will return the user with an empty Taskhub.

Extra note:
A new method `strictlyContains` is implemented instead of using `contains` because a user can modify other information of an employee and cause invocation errors.

This PR also updates `TypicalProjects` to use factory methods instead of static instances to prevent modifications to `TypicalTaskhub` between tests.