### PR TITLE
Fix invalid dates showing as valid

### DIFF
--- a/src/main/java/seedu/address/model/project/Deadline.java
+++ b/src/main/java/seedu/address/model/project/Deadline.java
@@ -5,6 +5,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.time.format.ResolverStyle;
 
 /**
  * Represents a Project's deadline in TaskHub.
@@ -16,12 +17,13 @@ public class Deadline {
             "Project deadline should be \n"
                     + "1. an empty string (to remove deadline); or \n"
                     + "2. a valid date in the dd-MM-yyyy format. Example: 17-02-2009";
-    public static final String DATE_FORMAT = "dd-MM-yyyy";
-    public static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern(DATE_FORMAT);
+    public static final String DATE_FORMAT = "dd-MM-uuuu";
+    public static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern(DATE_FORMAT)
+            .withResolverStyle(ResolverStyle.STRICT);
 
 
     /**
-     * Either dd-MM-yyyy or empty string
+     * Either dd-MM-uuuu or empty string
      */
     public final String value;
 

--- a/src/main/java/seedu/address/ui/ProjectCard.java
+++ b/src/main/java/seedu/address/ui/ProjectCard.java
@@ -95,7 +95,7 @@ public class ProjectCard extends UiPart<Region> {
             LocalDate currentDateTime = LocalDate.now(); // Get the current date
             LocalDate deadlineDate = project.getDeadline().getLocalDate(); // Get project deadline
 
-            String formattedDeadline = deadlineDate.format(DateTimeFormatter.ofPattern("dd-MM-yyyy"));
+            String formattedDeadline = deadlineDate.format(DateTimeFormatter.ofPattern("dd-MM-uuuu"));
             deadline.setText("Deadline: " + formattedDeadline);
 
             // Compare project deadline with current date

--- a/src/test/java/seedu/address/logic/parser/DeadlineProjectCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeadlineProjectCommandParserTest.java
@@ -59,7 +59,7 @@ public class DeadlineProjectCommandParserTest {
     @Test
     public void parse_invalidIndex_failure() {
         // Invalid index
-        String userInput = "-1" + " " + PREFIX_DEADLINE + "31-02-2023";
+        String userInput = "-1" + " " + PREFIX_DEADLINE + "28-02-2023";
         assertParseFailure(parser, userInput, String.format(ParserUtil.MESSAGE_INVALID_INDEX, "-1"));
     }
 }


### PR DESCRIPTION
Fixes #210, #212 and #220 .

`31-02-2021` used to be a valid user input date for project deadlines, and the program automatically changes it to `28-02-2021` as February does not have 31 days. This is no longer the case, and the program is more strict in disallowing such invalid inputs.

Codecov fails due to test-coverage, but it's a non-issue.