### PR TITLE
Fix wrong date format in editP error message

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditProjectCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditProjectCommand.java
@@ -36,7 +36,7 @@ public class EditProjectCommand extends Command {
             + "[" + PREFIX_DEADLINE + "DEADLINE] "
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PRIORITY + "HIGH "
-            + PREFIX_DEADLINE + "2020-12-31";
+            + PREFIX_DEADLINE + "28-02-2022";
 
     public static final String MESSAGE_EDIT_PROJECT_SUCCESS = "Edited Project: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";


### PR DESCRIPTION
Closes #204 

Error message wrongly shows the date in an incorrect format (`2020-12-31`), when it should show in a correct format (`31-12-2020`), for the `editP` command format. This has been fixed.